### PR TITLE
Add ca-certificates

### DIFF
--- a/docker/phpcs-server/Dockerfile
+++ b/docker/phpcs-server/Dockerfile
@@ -11,6 +11,7 @@ RUN set -x \
         php7-simplexml \
         php7-tokenizer \
         php7-xmlwriter \
+        ca-certificates \
     && apk add --no-cache -t .build-deps \
         curl \
         php7-json \


### PR DESCRIPTION
SSL interaction with AWS is not working correctly so adding common CA certificates PEM files.