### PR TITLE
Add a YAML generator for GCP deployments

### DIFF
--- a/bin/tpl.sh
+++ b/bin/tpl.sh
@@ -19,7 +19,7 @@ ${CYAN}The ${RESET}${BOLD}.env${RESET}${CYAN} file is sourced even if a custom e
 All paths are relative to the project ${RESET}${BOLD}root${RESET}${CYAN}.${RESET}"
 
 
-## Handle help parameters.
+## Handle cli parameters.
 for p in "$@";
 do
     case $p in

--- a/bin/tpl.sh
+++ b/bin/tpl.sh
@@ -1,32 +1,76 @@
 #!/bin/bash
 
-TEMPLATE="$1"
-DESTINATION="$2"
+## Output styles.
+BOLD=$(tput bold)
+RED=$(tput setaf 1)
+YELLOW=$(tput setaf 3)
+CYAN=$(tput setaf 6)
+RESET=$(tput sgr0)
 
+## CLI messages.
+HELP="Pass [${CYAN}--help${RESET}|${CYAN}-h${RESET}] as a cli argument for help using this script."
+ERROR="${RED}${BOLD}Error${RESET}:"
+USAGE="${BOLD}Usage${RESET}:
+    $0 {${RED}template${RESET}} {${RED}destination${RESET}} {${YELLOW}environment${RESET}}
+${BOLD}Notes${RESET}:${CYAN}
+    1. The default ${RESET}${BOLD}.env${RESET}${CYAN} file is always sourced.
+    2. All file paths are relative to the project ${RESET}${BOLD}root${RESET}${CYAN}.${RESET}
+${BOLD}Arguments${RESET}:
+    ${CYAN}template${RESET}:
+        The template file used to generate the destination file. (${RED}required${RESET})
+    ${CYAN}destination${RESET}:
+        The destination file that is generated from the template file. (${RED}required${RESET})
+    ${CYAN}environment${RESET}:
+        The environment file used to source custom environment variables. (${YELLOW}optional${RESET})"
+
+## Handle help parameters.
+for p in "$@";
+do
+    case $p in
+    --help|-h)
+        echo "${USAGE}"
+        exit 0;
+        ;;
+    esac
+done
+
+## Validate cli arguments.
+if [ $# -lt 1 ]; then
+    echo "${ERROR}
+    Missing required {${RED}template${RESET}} and {${RED}destination${RESET}} arguments.
+    ${HELP}"
+    exit 1
+elif [ $# -lt 2 ]; then
+    echo "${ERROR}
+    Missing required {${RED}destination${RESET}} argument.
+    ${HELP}"
+    exit 1
+fi
+
+## Check for envsubst command.
+if ! command -v envsubst >/dev/null 2>&1; then
+    echo "${ERROR}
+    Variable Interpolation failure. The ${RED}envsubst${RESET} command is not installed on your OS."
+    exit 1
+fi
+
+## Validate template file.
+if [ ! -e ${1} ]; then
+    echo "${ERROR}
+    The template file (${RED}${BOLD}${1}${RESET}) does not exist at the location provided.
+    ${HELP}"
+    exit 1
+fi
+
+# Source .env file.
 if [ -e .env ]; then
     export $(cat .env | grep -v ^# | xargs)
 fi
 
-if [ -e .env.prod ]; then
-    export $(cat .env.prod | grep -v ^# | xargs)
+## Source custom environment file.
+if [ ! -z ${3} ] && [ -e ${3} ]; then
+    export $(cat ${3} | grep -v ^# | xargs)
 fi
 
-if ! command -v envsubst >/dev/null 2>&1; then
-    echo "Variable Interpolation failure: envsubst is not installed"
-    exit 1
-fi
-
-if [ -z ${1} ]; then
-    echo "The template file is required."
-    exit 1
-elif [ ! -e ${1} ]; then
-    echo "The template file does not exist."
-    exit 1
-fi
-
-if [ -z ${2} ]; then
-    echo "The destination file is required."
-    exit 1
-fi
-
+## Substitute environment variables and generate destination file.
 envsubst < "$1" > "$2"

--- a/bin/tpl.sh
+++ b/bin/tpl.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+TEMPLATE="$1"
+DESTINATION="$2"
+
+if [ -e .env ]; then
+    export $(cat .env | grep -v ^# | xargs)
+fi
+
+if [ -e .env.prod ]; then
+    export $(cat .env.prod | grep -v ^# | xargs)
+fi
+
+if ! command -v envsubst >/dev/null 2>&1; then
+    echo "Variable Interpolation failure: envsubst is not installed"
+    exit 1
+fi
+
+if [ -z ${1} ]; then
+    echo "The template file is required."
+    exit 1
+elif [ ! -e ${1} ]; then
+    echo "The template file does not exist."
+    exit 1
+fi
+
+if [ -z ${2} ]; then
+    echo "The destination file is required."
+    exit 1
+fi
+
+envsubst < "$1" > "$2"

--- a/bin/tpl.sh
+++ b/bin/tpl.sh
@@ -15,7 +15,8 @@ USAGE="usage: $0 [<options>]
     -f, --file      name of the .tpl file (without extension) (${RED}required${RESET})
     -e, --env       environment file used to source custom environment variables (${YELLOW}optional${RESET})
 
-${CYAN}The default ${RESET}${BOLD}.env${RESET}${CYAN} file is always sourced and all file paths are relative to the project ${RESET}${BOLD}root${RESET}${CYAN}.${RESET}"
+${CYAN}The ${RESET}${BOLD}.env${RESET}${CYAN} file is sourced even if a custom environment file is used.
+All paths are relative to the project ${RESET}${BOLD}root${RESET}${CYAN}.${RESET}"
 
 
 ## Handle help parameters.


### PR DESCRIPTION
The `tpl.sh` script will convert a `.tpl` to a `.yaml` file (or any file type), and dynamically insert the environment variable into it using `envsubst`. This will allow us to create a deployment file like so:

```
sync.tpl.deployment:
    @./bin/tpl.sh -p=docker/sync-server/ -f=deployment -e=.env.prod
```

Which will make it so we can also create a secrets and persistent volumes file and generally have more control over the deployments as the `kubectl` and `gcloud` commands are limiting in this respect.

closes #35 