### PR TITLE
Create Sync Server deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ report.json
 
 # Server data
 data
+
+# GKE YAML Configurations
+app-deployment.yaml

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ VERSION=0.1.0
 BUILD=`git rev-parse HEAD`
 
 # Docker settings.
-REPO=gcr.io/${GCP_PROJECT}
+export REPO=gcr.io/${GCP_PROJECT}
 
 # GO settings.
 GOOS=linux

--- a/docker/sync-server/Makefile
+++ b/docker/sync-server/Makefile
@@ -1,5 +1,5 @@
 # Sync Server Docker settings.
-SYNC_TAG=${SYNC_GKE_IMAGE}:${VERSION}
+export SYNC_TAG=${SYNC_GKE_IMAGE}:${VERSION}
 
 # Sync Server GO settings.
 SYNC_BIN_PATH=bin/sync-server
@@ -68,7 +68,7 @@ sync.clean.image:
 
 # Build the Sync Server GKE cluster.
 sync.build.cluster: config
-	@gcloud beta container --project ${GCP_PROJECT} clusters create ${SYNC_GKE_CLUSTER} \
+	@gcloud container --project ${GCP_PROJECT} clusters create ${SYNC_GKE_CLUSTER} \
 	--zone ${GCP_ZONE} \
 	--cluster-version ${SYNC_GKE_CLUSTER_VERSION} \
 	--machine-type ${SYNC_GKE_MACHINE_TYPE} \
@@ -78,11 +78,7 @@ sync.build.cluster: config
 	--preemptible \
 	--num-nodes 1 \
 	--enable-cloud-logging \
-	--enable-cloud-monitoring \
-	--enable-autoscaling \
-	--min-nodes 1 \
-	--max-nodes 1 \
-	--enable-legacy-authorization
+	--enable-cloud-monitoring
 
 # Get the Sync Server GKE cluster credentials.
 sync.creds:
@@ -90,29 +86,8 @@ sync.creds:
 
 # Deploy the Sync Server GKE cluster.
 sync.deploy.cluster: config sync.creds
-	@kubectl run ${SYNC_GKE_CLUSTER} --image=${REPO}/${SYNC_TAG} --replicas=1 \
-	--env="TIDE_API_HOST=${TIDE_API_HOST}" \
-	--env="TIDE_API_PROTOCOL=${TIDE_API_PROTOCOL}" \
-	--env="TIDE_API_VERSION=${TIDE_API_VERSION}" \
-	--env="SYNC_ACTIVE=${SYNC_ACTIVE}" \
-	--env="SYNC_API_BROWSE_CATEGORY=${SYNC_API_BROWSE_CATEGORY}" \
-	--env="SYNC_DATA=${SYNC_DATA}" \
-	--env="SYNC_DEFAULT_CLIENT=${SYNC_DEFAULT_CLIENT}" \
-	--env="SYNC_DEFAULT_VISIBILITY=${SYNC_DEFAULT_VISIBILITY}" \
-	--env="SYNC_FORCE_AUDITS=${SYNC_FORCE_AUDITS}" \
-	--env="SYNC_ITEMS_PER_PAGE=${SYNC_ITEMS_PER_PAGE}" \
-	--env="SYNC_POOL_DELAY=${SYNC_POOL_DELAY}" \
-	--env="SYNC_POOL_WORKERS=${SYNC_POOL_WORKERS}" \
-	--env="PHPCS_SQS_KEY=${PHPCS_SQS_KEY}" \
-	--env="PHPCS_SQS_QUEUE=${PHPCS_SQS_QUEUE}" \
-	--env="PHPCS_SQS_QUEUE_NAME=${PHPCS_SQS_QUEUE_NAME}" \
-	--env="PHPCS_SQS_REGION=${PHPCS_SQS_REGION}" \
-	--env="PHPCS_SQS_SECRET=${PHPCS_SQS_SECRET}" \
-	--env="LH_SQS_KEY=${LH_SQS_KEY}" \
-	--env="LH_SQS_QUEUE=${LH_SQS_QUEUE}" \
-	--env="LH_SQS_QUEUE_NAME=${LH_SQS_QUEUE_NAME}" \
-	--env="LH_SQS_REGION=${LH_SQS_REGION}" \
- 	--env="LH_SQS_SECRET=${LH_SQS_SECRET}"
+	@./bin/tpl.sh -p=docker/sync-server/ -f=app-deployment -e=.env.prod
+	@kubectl apply -f ./docker/sync-server/app-deployment.yaml
 
 # Get the Sync Server GKE cluster status.
 sync.get.cluster:
@@ -120,4 +95,5 @@ sync.get.cluster:
 
 # Clean the Sync Server GKE cluster.
 sync.clean.cluster: config
+	@kubectl delete -f ./docker/sync-server/app-deployment.yaml
 	@gcloud container clusters delete ${SYNC_GKE_CLUSTER} -q

--- a/docker/sync-server/app-deployment.tpl
+++ b/docker/sync-server/app-deployment.tpl
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sync-server-secret
+type: Opaque
+stringData:
+  LH_SQS_KEY: $LH_SQS_KEY
+  LH_SQS_SECRET: $LH_SQS_SECRET
+  PHPCS_SQS_KEY: $PHPCS_SQS_KEY
+  PHPCS_SQS_SECRET: $PHPCS_SQS_SECRET
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sync-server-pv-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sync-server-deployment
+  labels:
+    app: sync-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sync-server
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: sync-server
+    spec:
+      containers:
+      - image: ${REPO}/${SYNC_TAG}
+        name: sync-server
+        env:
+        - name: TIDE_API_HOST
+          value: "${TIDE_API_HOST}"
+        - name: TIDE_API_PROTOCOL
+          value: "${TIDE_API_PROTOCOL}"
+        - name: TIDE_API_VERSION
+          value: "${TIDE_API_VERSION}"
+        - name: SYNC_ACTIVE
+          value: "${SYNC_ACTIVE}"
+        - name: SYNC_API_BROWSE_CATEGORY
+          value: "${SYNC_API_BROWSE_CATEGORY}"
+        - name: SYNC_DATA
+          value: "${SYNC_DATA}"
+        - name: SYNC_DEFAULT_CLIENT
+          value: "${SYNC_DEFAULT_CLIENT}"
+        - name: SYNC_DEFAULT_VISIBILITY
+          value: "${SYNC_DEFAULT_VISIBILITY}"
+        - name: SYNC_FORCE_AUDITS
+          value: "${SYNC_FORCE_AUDITS}"
+        - name: SYNC_ITEMS_PER_PAGE
+          value: "${SYNC_ITEMS_PER_PAGE}"
+        - name: SYNC_POOL_DELAY
+          value: "${SYNC_POOL_DELAY}"
+        - name: SYNC_POOL_WORKERS
+          value: "${SYNC_POOL_WORKERS}"
+        - name: PHPCS_SQS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: sync-server-secret
+              key: PHPCS_SQS_KEY
+        - name: PHPCS_SQS_QUEUE
+          value: "${PHPCS_SQS_QUEUE}"
+        - name: PHPCS_SQS_QUEUE_NAME
+          value: "${PHPCS_SQS_QUEUE_NAME}"
+        - name: PHPCS_SQS_REGION
+          value: "${PHPCS_SQS_REGION}"
+        - name: PHPCS_SQS_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: sync-server-secret
+              key: PHPCS_SQS_SECRET
+        - name: LH_SQS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: sync-server-secret
+              key: LH_SQS_KEY
+        - name: LH_SQS_QUEUE
+          value: "${LH_SQS_QUEUE}"
+        - name: LH_SQS_QUEUE_NAME
+          value: "${LH_SQS_QUEUE_NAME}"
+        - name: LH_SQS_REGION
+          value: "${LH_SQS_REGION}"
+        - name: LH_SQS_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: sync-server-secret
+              key: LH_SQS_SECRET
+        volumeMounts:
+        - name: sync-server-persistent-storage
+          mountPath: $SYNC_DATA
+      volumes:
+      - name: sync-server-persistent-storage
+        persistentVolumeClaim:
+          claimName: sync-server-pv-claim


### PR DESCRIPTION
Makes use of the new `./bin/tpl.sh` script and sets up the Sync Server deployment in a more sane way, and with a persistent volume claim.