### PR TITLE
Add Lighthouse to the SQS message

### DIFF
--- a/cmd/sync-server/dispatcher.go
+++ b/cmd/sync-server/dispatcher.go
@@ -39,6 +39,11 @@ func (s sqsDispatcher) Dispatch(project wporg.RepoProject) error {
 		msg.SourceURL = "https://downloads.wordpress.org/theme/" + project.Slug + "." + project.Version + ".zip"
 		msg.ProjectType = "theme"
 		msg.Content = project.Description
+		msg.Standards = append(msg.Standards, "lighthouse")
+		*msg.Audits = append(*msg.Audits,message.Audit{
+			Type: "lighthouse",
+			Options: &message.AuditOption{},
+		})
 	case "plugins":
 		msg.SourceURL = project.DownloadLink
 		msg.ProjectType = "plugin"


### PR DESCRIPTION
I've tested that the Sync Server produces the same SQS message as a `POST` request to the API. Except that the options array in the API is empty and the Sync Server has:
```
{
    "standard":"",
    "report":""
}
```

This closes #30 