### PR TITLE
Add MongoDB PHP Driver to API.

### DIFF
--- a/service/api/docker/Dockerfile
+++ b/service/api/docker/Dockerfile
@@ -6,6 +6,18 @@ RUN /build-scripts/composer.sh
 
 RUN apt-get update && apt-get install -y autoconf make gcc
 
+# Get and make mongodb PHP driver
+RUN yes | apt-get install libssl-dev \
+	&& git clone https://github.com/mongodb/mongo-php-driver.git --recursive \
+	&& cd mongo-php-driver \
+	&& phpize \
+	&& ./configure --with-mongodb-ssl=openssl \
+	&& make all \
+	&& make install \
+	&& echo "extension=mongodb.so" > /opt/php${SHORT_VERSION}/lib/conf.d/ext-mongodb.ini \
+	&& cd .. \
+	&& rm -rf mongo-php-driver
+
 # Install Xdebug
 RUN yes | pecl install xdebug \
     && echo "zend_extension=$(find /opt/php${SHORT_VERSION}/lib/x86_64-linux-gnu/extensions/no-debug-non-zts-20170718/ -name xdebug.so)" > /opt/php${SHORT_VERSION}/lib/conf.d/xdebug.ini \


### PR DESCRIPTION
### Description of the Change

Adding MongoDB PHP Driver to the Docker container.

### Benefits

Required so that we can add a Mongo message provider to the API for local development.

### Verification Process

Build succeeds. Running the image and "shelling" into it you can verify by running:

```
php -i | grep mongo
```

### Applicable Issues

New issue discussed today in dev sync meeting.
