### PR TITLE
do an apt-get update first

### DIFF
--- a/service/api/Dockerfile
+++ b/service/api/Dockerfile
@@ -1,10 +1,7 @@
 FROM gcr.io/google-appengine/php72:latest
 
-# Update repos
-RUN apt-get update
-
-# Install GCC
-RUN apt-get install -y autoconf make gcc
+# Update repos & Install GCC
+RUN apt-get update && apt-get install -y autoconf make gcc
 
 # Install Xdebug
 RUN yes | pecl install xdebug \

--- a/service/api/Dockerfile
+++ b/service/api/Dockerfile
@@ -1,5 +1,9 @@
 FROM gcr.io/google-appengine/php72:latest
 
+# Update repos
+RUN apt-get update
+
+# Install GCC
 RUN apt-get install -y autoconf make gcc
 
 # Install Xdebug


### PR DESCRIPTION
@rheinardkorf when running `make api.up` I got the following:
```
Reading package lists...
Building dependency tree...
Reading state information...
Package make is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Unable to locate package autoconf
E: Package 'make' has no installation candidate
E: Unable to locate package gcc
ERROR: Service 'api-php' failed to build: The command '/bin/sh -c apt-get install -y autoconf make gcc' returned a non-zero code: 100
make: *** [api.up] Error 1
```

The solution for me was to add in `apt-update` first then run the install.