### PR TITLE
Install MongoDB with composer build script locally & on GCP

### DIFF
--- a/service/api/composer.json
+++ b/service/api/composer.json
@@ -8,6 +8,7 @@
   "require": {
     "php": "7.2.*",
     "ext-redis": "*",
+    "ext-mongodb": "*",
     "google/cloud": "0.67",
     "johnpbloch/wordpress-core-installer": "^1",
     "johnpbloch/wordpress-core": "4.9.6",
@@ -43,7 +44,8 @@
   "config": {
     "platform": {
       "php": "7.2",
-      "ext-redis": "3.2"
+      "ext-redis": "3.2",
+      "ext-mongodb": "1.4.3"
     }
   }
 }

--- a/service/api/composer.lock
+++ b/service/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "706752cdc77c59e4b92331f56d0e9ddc",
+    "content-hash": "fc2e085274493f2ba89d8047e7da98ed",
     "packages": [
         {
             "name": "composer/installers",
@@ -382,21 +382,21 @@
         },
         {
             "name": "google/gax",
-            "version": "0.33.0",
+            "version": "0.33.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/gax-php.git",
-                "reference": "9f975d6ebf2b7c7a064c22e3f7fc6818052fd387"
+                "reference": "9d15f56374ab3940f5f11761cfefc7dfb18ea363"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/9f975d6ebf2b7c7a064c22e3f7fc6818052fd387",
-                "reference": "9f975d6ebf2b7c7a064c22e3f7fc6818052fd387",
+                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/9d15f56374ab3940f5f11761cfefc7dfb18ea363",
+                "reference": "9d15f56374ab3940f5f11761cfefc7dfb18ea363",
                 "shasum": ""
             },
             "require": {
                 "google/auth": "^1.2.0",
-                "google/protobuf": "^3.5.1",
+                "google/protobuf": "3.5.*",
                 "grpc/grpc": "^1.4",
                 "guzzlehttp/promises": "^1.3",
                 "guzzlehttp/psr7": "^1.2",
@@ -429,7 +429,7 @@
             "keywords": [
                 "google"
             ],
-            "time": "2018-05-24T17:47:50+00:00"
+            "time": "2018-06-07T17:09:36+00:00"
         },
         {
             "name": "google/proto-client",
@@ -4552,11 +4552,13 @@
     "prefer-lowest": false,
     "platform": {
         "php": "7.2.*",
-        "ext-redis": "*"
+        "ext-redis": "*",
+        "ext-mongodb": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.2",
-        "ext-redis": "3.2"
+        "ext-redis": "3.2",
+        "ext-mongodb": "1.4.3"
     }
 }

--- a/service/api/docker/Dockerfile
+++ b/service/api/docker/Dockerfile
@@ -4,19 +4,10 @@ COPY composer.json ${APP_DIR}/composer.json
 
 RUN /build-scripts/composer.sh
 
-RUN apt-get update && apt-get install -y autoconf make gcc
-
-# Get and make mongodb PHP driver
-RUN yes | apt-get install libssl-dev \
-	&& git clone https://github.com/mongodb/mongo-php-driver.git --recursive \
-	&& cd mongo-php-driver \
-	&& phpize \
-	&& ./configure --with-mongodb-ssl=openssl \
-	&& make all \
-	&& make install \
-	&& echo "extension=mongodb.so" > /opt/php${SHORT_VERSION}/lib/conf.d/ext-mongodb.ini \
-	&& cd .. \
-	&& rm -rf mongo-php-driver
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    make \
+    gcc
 
 # Install Xdebug
 RUN yes | pecl install xdebug \

--- a/service/api/docker/composer.json
+++ b/service/api/docker/composer.json
@@ -1,6 +1,7 @@
 {
   "require": {
     "php": "7.2.*",
-    "ext-redis": "*"
+    "ext-redis": "*",
+    "ext-mongodb": "*"
   }
 }


### PR DESCRIPTION
Removes the need to build the extension locally from source since the GCP docker build script already supports MongoDB.