### PR TITLE
add docs website props

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,13 +734,13 @@ a chat service, sometimes it takes several hours for community members to respon
 — please be patient.
 
 ### Credits
-Props: [Brendan Woods (@brendanwoods-xwp)](https://github.com/brendanwoods-xwp), 
+Props: [Bartek Makoś (@MakiBM)](https://github.com/MakiBM), [Brendan Woods (@brendanwoods-xwp)](https://github.com/brendanwoods-xwp), 
 [Daniel Louw (@danlouw)](https://github.com/danlouw), 
 [David Cramer (@davidcramer)](https://github.com/davidcramer), 
 [David Lonjon (@davidlonjon)](https://github.com/davidlonjon), 
 [Derek Herman (@valendesigns)](https://github.com/valendesigns), 
 [Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul), 
-[Justin Kopepasah (@kopepasah)](https://github.com/kopepasah), 
+[Justin Kopepasah (@kopepasah)](https://github.com/kopepasah), [Leo Postovoit (@postphotos)](https://github.com/postphotos), [Lubos Kmetko (@luboskmetko)](https://github.com/luboskmetko), 
 [Luke Carbis (@lukecarbis)](https://github.com/lukecarbis), 
 [Miina Sikk (@miina)](https://github.com/miina), 
 [Mike Crantea (@mehigh)](https://github.com/mehigh), 

--- a/README.md
+++ b/README.md
@@ -735,13 +735,16 @@ a chat service, sometimes it takes several hours for community members to respon
 — please be patient.
 
 ### Credits
-Props: [Bartek Makoś (@MakiBM)](https://github.com/MakiBM), [Brendan Woods (@brendanwoods-xwp)](https://github.com/brendanwoods-xwp), 
+Props: [Bartek Makoś (@MakiBM)](https://github.com/MakiBM), 
+[Brendan Woods (@brendanwoods-xwp)](https://github.com/brendanwoods-xwp), 
 [Daniel Louw (@danlouw)](https://github.com/danlouw), 
 [David Cramer (@davidcramer)](https://github.com/davidcramer), 
 [David Lonjon (@davidlonjon)](https://github.com/davidlonjon), 
 [Derek Herman (@valendesigns)](https://github.com/valendesigns), 
 [Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul), 
-[Justin Kopepasah (@kopepasah)](https://github.com/kopepasah), [Leo Postovoit (@postphotos)](https://github.com/postphotos), [Lubos Kmetko (@luboskmetko)](https://github.com/luboskmetko), 
+[Justin Kopepasah (@kopepasah)](https://github.com/kopepasah), 
+[Leo Postovoit (@postphotos)](https://github.com/postphotos), 
+[Lubos Kmetko (@luboskmetko)](https://github.com/luboskmetko), 
 [Luke Carbis (@lukecarbis)](https://github.com/lukecarbis), 
 [Miina Sikk (@miina)](https://github.com/miina), 
 [Mike Crantea (@mehigh)](https://github.com/mehigh), 


### PR DESCRIPTION
### Description of the Change

Adds the list of contributors for the demonstration/documentation website to list of Tide Credits.

### Benefits

Thanks [Bartek Makoś](https://github.com/MakiBM), [Leo Postovoit](https://github.com/postphotos), and [Lubos Kmetko](https://github.com/luboskmetko) for their effort.

### Possible Drawbacks

None.

### Verification Process

Verified changes with GH's live preview functionality.

### Applicable Issues

Related to #118.
