### PR TITLE
This commit fixes 'gofmt', 'golint' and 'govet' issues.

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -80,7 +80,7 @@ SYNC_POOL_WORKERS=125
 #-- Google Cloud Platform ---------------------------------------
 #----------------------------------------------------------------
 
-GCP_PROJECT=<CHANGE_THIS_VALUE>
+GCP_PROJECT=tide-local
 GCP_REGION=<CHANGE_THIS_VALUE>
 GCP_ZONE=<CHANGE_THIS_VALUE>
 

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ GCP. Be sure to use the same region you chose during the earlier
 
 | Variable | Description |
 | :--- | :--- |
-| `GCP_PROJECT` | The unique ID of you Google project. |
+| `GCP_PROJECT` | The unique ID of you Google project. Default is `tide-local`. Note: you must update this value if you plan to use **any** GCP resources, for purely local development the default value will work as-is. |
 | `GCP_REGION` | The [region][regions-and-zones] where all your resources will be created. For example, `us-west1`. |
 | `GCP_ZONE` | The preferred [zone][regions-and-zones] in your region that resources will be created, For example, `us-west1-a`. |
 

--- a/cmd/lighthouse-server/main.go
+++ b/cmd/lighthouse-server/main.go
@@ -27,7 +27,7 @@ import (
 type processConfig struct {
 	igTempFolder      string
 	lhTempFolder      string
-	lhStorageProvider storage.StorageProvider
+	lhStorageProvider storage.Provider
 	resPayloaders     map[string]payload.Payloader
 }
 
@@ -266,7 +266,7 @@ func processMessage(msg message.Message, wg *sync.WaitGroup) error {
 
 // pollProvider polls the message provider for
 // the next message and upon success it gets added to the channel.
-func pollProvider(c chan message.Message, provider message.MessageProvider) {
+func pollProvider(c chan message.Message, provider message.Provider) {
 
 	// Run this concurrently.
 	go func() {
@@ -316,7 +316,7 @@ func executeProcessFunc(proc process.Processor, msg message.Message, result *pro
 
 // getStorageProvider returns a storage provider given the provided configurations from
 // the environment variables.
-func getStorageProvider(config map[string]map[string]string) storage.StorageProvider {
+func getStorageProvider(config map[string]map[string]string) storage.Provider {
 	switch config["app"]["storage_provider"] {
 	case "s3":
 		conf := config["aws"]
@@ -333,7 +333,7 @@ func getStorageProvider(config map[string]map[string]string) storage.StorageProv
 
 // getStorageProvider returns a message/queue provider given the provided configurations
 // from the environment variables.
-func getMessageProvider(config map[string]map[string]string) message.MessageProvider {
+func getMessageProvider(config map[string]map[string]string) message.Provider {
 
 	switch config["app"]["message_provider"] {
 	case "sqs":

--- a/cmd/lighthouse-server/main.go
+++ b/cmd/lighthouse-server/main.go
@@ -1,26 +1,27 @@
 package main
 
 import (
-	"github.com/wptide/pkg/message"
-	tideApi "github.com/wptide/pkg/tide"
-	"github.com/wptide/pkg/tide/api"
-	"github.com/wptide/pkg/message/sqs"
-	"time"
-	"log"
-	"github.com/wptide/pkg/env"
-	"github.com/wptide/pkg/storage"
-	"github.com/wptide/pkg/process"
-	"github.com/wptide/pkg/payload"
-	"fmt"
-	"flag"
-	"github.com/wptide/pkg/source"
-	"sync"
-	"github.com/wptide/pkg/storage/gcs"
 	"context"
-	"github.com/wptide/pkg/storage/s3"
-	"github.com/wptide/pkg/storage/local"
+	"flag"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/wptide/pkg/env"
+	"github.com/wptide/pkg/message"
 	"github.com/wptide/pkg/message/firestore"
 	"github.com/wptide/pkg/message/mongo"
+	"github.com/wptide/pkg/message/sqs"
+	"github.com/wptide/pkg/payload"
+	"github.com/wptide/pkg/process"
+	"github.com/wptide/pkg/source"
+	"github.com/wptide/pkg/storage"
+	"github.com/wptide/pkg/storage/gcs"
+	"github.com/wptide/pkg/storage/local"
+	"github.com/wptide/pkg/storage/s3"
+	tideApi "github.com/wptide/pkg/tide"
+	"github.com/wptide/pkg/tide/api"
 )
 
 type processConfig struct {
@@ -31,15 +32,16 @@ type processConfig struct {
 }
 
 var (
-	/** Compile time variables. **/
-	Version string // Set during build.
-	Build   string // Set during build.
+	// Version is the binary version set during build.
+	Version string
+
+	// Build is the binary build number set during build.
+	Build string
 
 	// Lighthouse service configuration (as var so that we can also override).
 	serviceConfig = getServiceConfig()
 
-	/** Initialize interface instances **/
-	// Use the interface so that we can test.
+	// TideClient represents the instance that will write to the Tide API.
 	TideClient tideApi.ClientInterface = &api.Client{}
 
 	// Specify the payloads to be used for this service.
@@ -80,7 +82,7 @@ var (
 	bVersion = &[]bool{false}[0]
 
 	// A single URL to process. Will not poll queue.
-	flagUrl = &[]string{""}[0]
+	flagURL = &[]string{""}[0]
 
 	// Project visibility for URL. "private" or "public"
 	flagVisibility = &[]string{"private"}[0]
@@ -111,7 +113,7 @@ func main() {
 		flagOutput = flag.String("output", "", "send results to output file (json format)")
 
 		// A -url to run a single audit. Will not poll a queue.
-		flagUrl = flag.String("url", "", "audit single message from url")
+		flagURL = flag.String("url", "", "audit single message from url")
 
 		// A -visibility to run a single audit. Will not poll a queue.
 		flagVisibility = flag.String("visibility", "public", `"private" or "public" - default "pubic"`)
@@ -143,7 +145,7 @@ func main() {
 	}
 
 	// If -url is set then send a message using the URL.
-	if *flagUrl != "" {
+	if *flagURL != "" {
 
 		singleMessageType := "tide"
 		conf := serviceConfig["tide"]
@@ -161,8 +163,8 @@ func main() {
 				Title:               "Single Project",
 				Content:             "Single project URL provided.",
 				PayloadType:         singleMessageType,
-				SourceURL:           *flagUrl,
-				SourceType:          source.GetKind(*flagUrl),
+				SourceURL:           *flagURL,
+				SourceType:          source.GetKind(*flagURL),
 				Force:               true,
 				Visibility:          *flagVisibility,
 				RequestClient:       *flagClient,
@@ -178,7 +180,7 @@ func main() {
 
 	// Start polling the messageProvider if we didn't provide a url.
 	// Other processes can also queue the channel.
-	if *flagUrl == "" {
+	if *flagURL == "" {
 		log.Println("Polling message provider.")
 		pollProvider(cMessage, messageProvider)
 	}
@@ -254,9 +256,9 @@ func processMessage(msg message.Message, wg *sync.WaitGroup) error {
 		err := messageProvider.DeleteMessage(msg.ExternalRef)
 		if err != nil {
 			return err
-		} else {
-			log.Println("'" + msg.Title + "' removed from message queue.")
 		}
+
+		log.Println("'" + msg.Title + "' removed from message queue.")
 	}
 
 	return nil
@@ -360,8 +362,7 @@ func getServiceConfig() map[string]map[string]string {
 			"server_path":      "/srv/data",
 			"local_path":       "lighthouse",
 		},
-		"aws":
-		{
+		"aws": {
 			"key":        env.GetEnv("AWS_API_KEY", ""),
 			"secret":     env.GetEnv("AWS_API_SECRET", ""),
 			"sqs_region": env.GetEnv("AWS_SQS_REGION", ""),
@@ -369,22 +370,19 @@ func getServiceConfig() map[string]map[string]string {
 			"s3_region":  env.GetEnv("AWS_S3_REGION", ""),
 			"s3_bucket":  env.GetEnv("AWS_S3_BUCKET_NAME", ""),
 		},
-		"gcp":
-		{
+		"gcp": {
 			"project":    env.GetEnv("GCP_PROJECT", ""),
 			"gcs_bucket": env.GetEnv("GCS_BUCKET_NAME", ""),
 			"gcf_queue":  env.GetEnv("GCF_QUEUE_LH", "queue-lighthouse"),
 		},
-		"mongo":
-		{
+		"mongo": {
 			"user":     env.GetEnv("MONGO_DATABASE_USERNAME", ""),
 			"pass":     env.GetEnv("MONGO_DATABASE_PASSWORD", ""),
 			"host":     "localhost:27017",
 			"database": env.GetEnv("MONGO_DATABASE_NAME", "queue"),
 			"queue":    env.GetEnv("MONGO_QUEUE_LH", "lighthouse"),
 		},
-		"tide":
-		{
+		"tide": {
 			"key":      env.GetEnv("API_KEY", ""),
 			"secret":   env.GetEnv("API_SECRET", ""),
 			"auth":     env.GetEnv("API_AUTH_URL", ""),

--- a/cmd/lighthouse-server/main_test.go
+++ b/cmd/lighthouse-server/main_test.go
@@ -216,7 +216,7 @@ func resetServiceConfig() {
 func Test_pollProvider(t *testing.T) {
 	type args struct {
 		c        chan message.Message
-		provider message.MessageProvider
+		provider message.Provider
 	}
 	tests := []struct {
 		name string
@@ -394,7 +394,7 @@ func Test_getStorageProvider(t *testing.T) {
 					},
 				},
 			},
-			reflect.TypeOf(&s3.S3Provider{}),
+			reflect.TypeOf(&s3.Provider{}),
 		},
 		{
 			"GCS Provider",
@@ -466,7 +466,7 @@ func Test_getMessageProvider(t *testing.T) {
 					},
 				},
 			},
-			reflect.TypeOf(&sqs.SqsProvider{}),
+			reflect.TypeOf(&sqs.Provider{}),
 		},
 		{
 			"Firestore Provider",
@@ -481,7 +481,7 @@ func Test_getMessageProvider(t *testing.T) {
 					},
 				},
 			},
-			reflect.TypeOf(&firestore.FirestoreProvider{}),
+			reflect.TypeOf(&firestore.Provider{}),
 		},
 		{
 			"Mongo Provider",
@@ -499,7 +499,7 @@ func Test_getMessageProvider(t *testing.T) {
 					},
 				},
 			},
-			reflect.TypeOf(&mongo.MongoProvider{}),
+			reflect.TypeOf(&mongo.Provider{}),
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/lighthouse-server/main_test.go
+++ b/cmd/lighthouse-server/main_test.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/wptide/pkg/message"
+	"github.com/wptide/pkg/message/firestore"
+	"github.com/wptide/pkg/message/mongo"
+	"github.com/wptide/pkg/message/sqs"
 	"github.com/wptide/pkg/storage/gcs"
 	"github.com/wptide/pkg/storage/local"
 	"github.com/wptide/pkg/storage/s3"
-	"github.com/wptide/pkg/message/firestore"
-	"github.com/wptide/pkg/message/sqs"
-	"github.com/wptide/pkg/message/mongo"
 )
 
 var (
@@ -82,7 +82,7 @@ func Test_main(t *testing.T) {
 		parseFlags     bool
 		version        bool
 		authError      bool
-		flagUrl        *string
+		flagURL        *string
 		flagOutput     *string
 		flagVisibility *string
 		altConfig      *processConfig
@@ -141,7 +141,7 @@ func Test_main(t *testing.T) {
 			"Run Main - URL and Visibility Flag set",
 			args{
 				timeOut:        1,
-				flagUrl:        &[]string{testFileServer.URL + "/test.zip"}[0],
+				flagURL:        &[]string{testFileServer.URL + "/test.zip"}[0],
 				flagVisibility: &[]string{"public"}[0],
 			},
 		},
@@ -167,8 +167,8 @@ func Test_main(t *testing.T) {
 			}
 
 			// -url
-			if tt.args.flagUrl != nil && *tt.args.flagUrl != "" {
-				flagUrl = tt.args.flagUrl
+			if tt.args.flagURL != nil && *tt.args.flagURL != "" {
+				flagURL = tt.args.flagURL
 			}
 
 			// -visibility
@@ -183,10 +183,10 @@ func Test_main(t *testing.T) {
 			}
 
 			if tt.args.authError {
-				oldId := serviceConfig["tide"]["key"]
+				oldID := serviceConfig["tide"]["key"]
 				serviceConfig["tide"]["key"] = "error"
 				defer func() {
-					serviceConfig["tide"]["key"] = oldId
+					serviceConfig["tide"]["key"] = oldID
 				}()
 			}
 
@@ -457,8 +457,7 @@ func Test_getMessageProvider(t *testing.T) {
 					"app": {
 						"message_provider": "sqs",
 					},
-					"aws":
-					{
+					"aws": {
 						"key":        "",
 						"secret":     "",
 						"sqs_region": "",
@@ -476,8 +475,7 @@ func Test_getMessageProvider(t *testing.T) {
 					"app": {
 						"message_provider": "firestore",
 					},
-					"gcp":
-					{
+					"gcp": {
 						"project":   "mock-project-id",
 						"gcf_queue": "test-queue",
 					},
@@ -492,13 +490,12 @@ func Test_getMessageProvider(t *testing.T) {
 					"app": {
 						"message_provider": "local",
 					},
-					"mongo":
-					{
-						"user": "test",
-						"pass": "test",
-						"host": "localhost:27017",
+					"mongo": {
+						"user":     "test",
+						"pass":     "test",
+						"host":     "localhost:27017",
 						"database": "test-db",
-						"queue": "test-queue",
+						"queue":    "test-queue",
 					},
 				},
 			},

--- a/cmd/lighthouse-server/mock_test.go
+++ b/cmd/lighthouse-server/mock_test.go
@@ -1,19 +1,20 @@
 package main
 
 import (
-	"os"
-	"io"
-	"github.com/wptide/pkg/message"
-	"net/http/httptest"
-	"net/http"
-	"errors"
 	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+
+	"github.com/wptide/pkg/message"
 	"github.com/wptide/pkg/process"
 )
 
 /** ----------------------------------------------
-	Mock Storage Provider
- */
+Mock Storage Provider
+*/
 
 type mockStorage struct{}
 
@@ -81,8 +82,8 @@ func (m mockPayloader) SendPayload(destination string, payload []byte) ([]byte, 
 }
 
 /** ----------------------------------------------
-	Mock Message Provider
- */
+Mock Message Provider
+*/
 
 type mockMessageProvider struct {
 	Type string
@@ -124,15 +125,15 @@ func (m mockMessageProvider) Close() error {
 }
 
 /** ----------------------------------------------
-	Mock Tide Client
- */
+Mock Tide Client
+*/
 
 type mockTide struct {
 	apiError bool
 }
 
-func (m mockTide) Authenticate(clientId, clientSecret, authEndpoint string) error {
-	if clientId == "error" {
+func (m mockTide) Authenticate(clientID, clientSecret, authEndpoint string) error {
+	if clientID == "error" {
 		return errors.New("something went wrong")
 	}
 
@@ -149,15 +150,15 @@ func (m mockTide) SendPayload(method, endpoint, data string) (string, error) {
 }
 
 /** ----------------------------------------------
-	Mock file server
- */
+Mock file server
+*/
 
 var testFileServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 }))
 
 /** ----------------------------------------------
-	Mock failed process
- */
+Mock failed process
+*/
 type mockFailedProcess struct {
 	option    string
 	shouldErr bool
@@ -186,11 +187,11 @@ func (m mockFailedProcess) SetFilesPath(path string)       {}
 func (m mockFailedProcess) GetFilesPath() string           { return "" }
 
 /** ----------------------------------------------
-	Mock processes
- */
+Mock processes
+*/
 
 func mockProcResponse(pre string, msg message.Message) error {
-	if msg.Slug == pre + "Fail" {
+	if msg.Slug == pre+"Fail" {
 		return errors.New("something went wrong")
 	}
 	return nil

--- a/cmd/phpcs-server/main.go
+++ b/cmd/phpcs-server/main.go
@@ -30,7 +30,7 @@ import (
 type processConfig struct {
 	igTempFolder         string
 	phpcsTempFolder      string
-	phpcsStorageProvider storage.StorageProvider
+	phpcsStorageProvider storage.Provider
 	resPayloaders        map[string]payload.Payloader
 }
 
@@ -298,7 +298,7 @@ func processMessage(msg message.Message, wg *sync.WaitGroup) error {
 
 // pollProvider polls the message provider for
 // the next message and upon success it gets added to the channel.
-func pollProvider(c chan message.Message, provider message.MessageProvider) {
+func pollProvider(c chan message.Message, provider message.Provider) {
 
 	// Run this concurrently.
 	go func() {
@@ -392,7 +392,7 @@ func executePHPCSProcessFunc(proc process.Processor, msg message.Message, result
 
 // getStorageProvider returns a storage provider given the provided configurations from
 // the environment variables.
-func getStorageProvider(config map[string]map[string]string) storage.StorageProvider {
+func getStorageProvider(config map[string]map[string]string) storage.Provider {
 	switch config["app"]["storage_provider"] {
 	case "s3":
 		conf := config["aws"]
@@ -409,7 +409,7 @@ func getStorageProvider(config map[string]map[string]string) storage.StorageProv
 
 // getStorageProvider returns a message/queue provider given the provided configurations
 // from the environment variables.
-func getMessageProvider(config map[string]map[string]string) message.MessageProvider {
+func getMessageProvider(config map[string]map[string]string) message.Provider {
 	switch config["app"]["message_provider"] {
 	case "sqs":
 		conf := config["aws"]

--- a/cmd/phpcs-server/main_test.go
+++ b/cmd/phpcs-server/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"log"
 	"os"
 	"reflect"
@@ -18,7 +19,6 @@ import (
 	"github.com/wptide/pkg/storage/local"
 	"github.com/wptide/pkg/storage/s3"
 	"github.com/wptide/pkg/tide"
-	"errors"
 )
 
 var (
@@ -85,7 +85,7 @@ func Test_main(t *testing.T) {
 		parseFlags     bool
 		version        bool
 		authError      bool
-		flagUrl        *string
+		flagURL        *string
 		flagOutput     *string
 		flagVisibility *string
 		flagWPRuleset  *string
@@ -141,7 +141,7 @@ func Test_main(t *testing.T) {
 			args{
 				messageChannel: make(chan message.Message, 1),
 				timeOut:        1,
-				flagUrl:        &[]string{testFileServer.URL + "/test.zip"}[0],
+				flagURL:        &[]string{testFileServer.URL + "/test.zip"}[0],
 				flagVisibility: &[]string{"public"}[0],
 			},
 		},
@@ -200,10 +200,10 @@ func Test_main(t *testing.T) {
 			}
 
 			// -url
-			if tt.args.flagUrl != nil && *tt.args.flagUrl != "" {
-				flagUrl = tt.args.flagUrl
+			if tt.args.flagURL != nil && *tt.args.flagURL != "" {
+				flagURL = tt.args.flagURL
 				defer func() {
-					flagUrl = &[]string{""}[0]
+					flagURL = &[]string{""}[0]
 				}()
 			}
 
@@ -231,10 +231,10 @@ func Test_main(t *testing.T) {
 			}
 
 			if tt.args.authError {
-				oldId := serviceConfig["tide"]["key"]
+				oldID := serviceConfig["tide"]["key"]
 				serviceConfig["tide"]["key"] = "error"
 				defer func() {
-					serviceConfig["tide"]["key"] = oldId
+					serviceConfig["tide"]["key"] = oldID
 				}()
 			}
 

--- a/cmd/phpcs-server/main_test.go
+++ b/cmd/phpcs-server/main_test.go
@@ -264,7 +264,7 @@ func resetServiceConfig() {
 func Test_pollProvider(t *testing.T) {
 	type args struct {
 		c        chan message.Message
-		provider message.MessageProvider
+		provider message.Provider
 	}
 	tests := []struct {
 		name string
@@ -444,7 +444,7 @@ func Test_getStorageProvider(t *testing.T) {
 					},
 				},
 			},
-			reflect.TypeOf(&s3.S3Provider{}),
+			reflect.TypeOf(&s3.Provider{}),
 		},
 		{
 			"GCS Provider",
@@ -516,7 +516,7 @@ func Test_getMessageProvider(t *testing.T) {
 					},
 				},
 			},
-			reflect.TypeOf(&sqs.SqsProvider{}),
+			reflect.TypeOf(&sqs.Provider{}),
 		},
 		{
 			"Firestore Provider",
@@ -531,7 +531,7 @@ func Test_getMessageProvider(t *testing.T) {
 					},
 				},
 			},
-			reflect.TypeOf(&firestore.FirestoreProvider{}),
+			reflect.TypeOf(&firestore.Provider{}),
 		},
 		{
 			"Mongo Provider",
@@ -549,7 +549,7 @@ func Test_getMessageProvider(t *testing.T) {
 					},
 				},
 			},
-			reflect.TypeOf(&mongo.MongoProvider{}),
+			reflect.TypeOf(&mongo.Provider{}),
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/phpcs-server/mock_test.go
+++ b/cmd/phpcs-server/mock_test.go
@@ -1,19 +1,20 @@
 package main
 
 import (
-	"os"
-	"io"
-	"github.com/wptide/pkg/message"
-	"net/http/httptest"
-	"net/http"
-	"errors"
 	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+
+	"github.com/wptide/pkg/message"
 	"github.com/wptide/pkg/process"
 )
 
 /** ----------------------------------------------
-	Mock Storage Provider
- */
+Mock Storage Provider
+*/
 
 type mockStorage struct{}
 
@@ -81,8 +82,8 @@ func (m mockPayloader) SendPayload(destination string, payload []byte) ([]byte, 
 }
 
 /** ----------------------------------------------
-	Mock Message Provider
- */
+Mock Message Provider
+*/
 
 type mockMessageProvider struct {
 	Type string
@@ -121,15 +122,15 @@ func (m mockMessageProvider) Close() error {
 }
 
 /** ----------------------------------------------
-	Mock Tide Client
- */
+Mock Tide Client
+*/
 
 type mockTide struct {
 	apiError bool
 }
 
-func (m mockTide) Authenticate(clientId, clientSecret, authEndpoint string) error {
-	if clientId == "error" {
+func (m mockTide) Authenticate(clientID, clientSecret, authEndpoint string) error {
+	if clientID == "error" {
 		return errors.New("something went wrong")
 	}
 
@@ -146,15 +147,15 @@ func (m mockTide) SendPayload(method, endpoint, data string) (string, error) {
 }
 
 /** ----------------------------------------------
-	Mock file server
- */
+Mock file server
+*/
 
 var testFileServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 }))
 
 /** ----------------------------------------------
-	Mock phpcs process
- */
+Mock phpcs process
+*/
 type mockPHPCSProcess struct {
 	err error
 }
@@ -176,8 +177,8 @@ func (m mockPHPCSProcess) Do() error {
 }
 
 /** ----------------------------------------------
-	Mock processes
- */
+Mock processes
+*/
 
 func mockProcResponse(pre string, msg message.Message) error {
 	if msg.Slug == pre+"Fail" {

--- a/cmd/sync-server/checker.go
+++ b/cmd/sync-server/checker.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"github.com/wptide/pkg/wporg"
-	"github.com/nanobox-io/golang-scribble"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
-	"fmt"
+
+	"github.com/nanobox-io/golang-scribble"
+	"github.com/wptide/pkg/wporg"
 )
 
 var mutex = sync.Mutex{}

--- a/cmd/sync-server/firestore.go
+++ b/cmd/sync-server/firestore.go
@@ -16,7 +16,7 @@ type firestoreDispatcher struct {
 		Active     bool
 		Accepts    string // "all" or "themes" or "plugins"
 	}
-	providers map[string]message.MessageProvider
+	providers map[string]message.Provider
 }
 
 func (fs firestoreDispatcher) Dispatch(project wporg.RepoProject) error {

--- a/cmd/sync-server/firestore.go
+++ b/cmd/sync-server/firestore.go
@@ -1,15 +1,16 @@
 package main
 
 import (
-	"github.com/wptide/pkg/wporg"
-	"github.com/wptide/pkg/message"
-	"github.com/wptide/pkg/message/firestore"
 	"context"
 	"errors"
+
+	"github.com/wptide/pkg/message"
+	"github.com/wptide/pkg/message/firestore"
+	"github.com/wptide/pkg/wporg"
 )
 
 type firestoreDispatcher struct {
-	ProjectID  string
+	ProjectID   string
 	Collections map[string]struct {
 		Collection string
 		Active     bool
@@ -24,8 +25,8 @@ func (fs firestoreDispatcher) Dispatch(project wporg.RepoProject) error {
 
 	for collectionID, collection := range fs.Collections {
 		queueProvider, ok := fs.providers[collectionID]
-		if ! ok {
-			return errors.New("Could not access queue. Make sure the dispatcher is initialised.")
+		if !ok {
+			return errors.New("could not access queue: make sure the dispatcher is initialised")
 		}
 		if collection.Active && (collection.Accepts == project.Type || collection.Accepts == "all") {
 			err := queueProvider.SendMessage(msg)
@@ -35,12 +36,13 @@ func (fs firestoreDispatcher) Dispatch(project wporg.RepoProject) error {
 		}
 	}
 
-	return nil}
+	return nil
+}
 
 func (fs *firestoreDispatcher) Init() error {
 	for collectionID, collection := range fs.Collections {
 		messageProvider, ok := fs.providers[collectionID]
-		if ! ok {
+		if !ok {
 			messageProvider, _ = firestore.New(context.Background(), fs.ProjectID, collection.Collection)
 			fs.providers[collectionID] = messageProvider
 		}
@@ -49,7 +51,7 @@ func (fs *firestoreDispatcher) Init() error {
 }
 
 func (fs *firestoreDispatcher) Close() error {
-	for collectionID, _ := range fs.Collections {
+	for collectionID := range fs.Collections {
 		if messageProvider, ok := fs.providers[collectionID]; ok {
 			messageProvider.Close()
 		}

--- a/cmd/sync-server/firestore_test.go
+++ b/cmd/sync-server/firestore_test.go
@@ -54,7 +54,7 @@ func Test_firestoreDispatcher_Dispatch(t *testing.T) {
 			Active     bool
 			Accepts    string
 		}
-		providers map[string]message.MessageProvider
+		providers map[string]message.Provider
 	}
 	type args struct {
 		project wporg.RepoProject
@@ -71,7 +71,7 @@ func Test_firestoreDispatcher_Dispatch(t *testing.T) {
 			fields{
 				"fake-id",
 				testCollections,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			args{
 				wporg.RepoProject{
@@ -86,7 +86,7 @@ func Test_firestoreDispatcher_Dispatch(t *testing.T) {
 			fields{
 				"fake-id",
 				testCollections,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			args{
 				wporg.RepoProject{
@@ -101,7 +101,7 @@ func Test_firestoreDispatcher_Dispatch(t *testing.T) {
 			fields{
 				"fake-id",
 				testCollections,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			args{
 				wporg.RepoProject{
@@ -116,7 +116,7 @@ func Test_firestoreDispatcher_Dispatch(t *testing.T) {
 			fields{
 				"fake-id",
 				testCollections,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			args{
 				wporg.RepoProject{
@@ -154,7 +154,7 @@ func Test_firestoreDispatcher_Init(t *testing.T) {
 			Active     bool
 			Accepts    string
 		}
-		providers map[string]message.MessageProvider
+		providers map[string]message.Provider
 	}
 	tests := []struct {
 		name    string
@@ -166,7 +166,7 @@ func Test_firestoreDispatcher_Init(t *testing.T) {
 			fields{
 				"fake-id",
 				testCollections,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			false,
 		}}
@@ -192,7 +192,7 @@ func Test_firestoreDispatcher_Close(t *testing.T) {
 			Active     bool
 			Accepts    string
 		}
-		providers map[string]message.MessageProvider
+		providers map[string]message.Provider
 	}
 	tests := []struct {
 		name    string
@@ -204,7 +204,7 @@ func Test_firestoreDispatcher_Close(t *testing.T) {
 			fields{
 				"abc",
 				testCollections,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			false,
 		},

--- a/cmd/sync-server/firestore_test.go
+++ b/cmd/sync-server/firestore_test.go
@@ -37,7 +37,7 @@ var (
 )
 
 func initMockFSProviders(fs *firestoreDispatcher) {
-	for collectionID, _ := range fs.Collections {
+	for collectionID := range fs.Collections {
 		queueProvider, ok := fs.providers[collectionID]
 		if !ok {
 			queueProvider = &mockProvider{}

--- a/cmd/sync-server/main.go
+++ b/cmd/sync-server/main.go
@@ -1,17 +1,18 @@
 package main
 
 import (
-	"github.com/wptide/pkg/sync"
-	"github.com/wptide/pkg/message"
-	"github.com/wptide/pkg/wporg"
-	"time"
+	"context"
 	"fmt"
-	"strings"
-	"github.com/wptide/pkg/env"
 	"log"
 	"strconv"
-	"context"
+	"strings"
+	"time"
+
+	"github.com/wptide/pkg/env"
+	"github.com/wptide/pkg/message"
+	"github.com/wptide/pkg/sync"
 	"github.com/wptide/pkg/sync/firestore"
+	"github.com/wptide/pkg/wporg"
 )
 
 var (
@@ -105,7 +106,7 @@ func fetcher(projectType, category string, bufferSize int, token chan struct{}, 
 					// If the latest item's update time is less than the recorded last updated item
 					// then set pages out of bounds to break the next loop.
 					// We won't `continue` yet and might as well continue looping the items we have.
-					if ! timeAfterEqual(*mostRecent, lastSync, timeFormat) {
+					if !timeAfterEqual(*mostRecent, lastSync, timeFormat) {
 						page = pages
 						pages = 0
 					}
@@ -128,7 +129,7 @@ func fetcher(projectType, category string, bufferSize int, token chan struct{}, 
 					}
 				}
 
-				page += 1
+				page++
 			}
 
 			// Set sync stop time for projectType.
@@ -233,15 +234,15 @@ func main() {
 
 	// SYNC_ACTIVE must be set to "on". This is to ensure you know what you are
 	// doing and not flooding message queues.
-	if ! serverActive {
+	if !serverActive {
 		log.Println("Sync Server not active. Please set ENV variable `SYNC_ACTIVE=on`.")
-		return;
+		return
 	}
 
 	// If sync client doesn't exist then exit.
 	if checkerError != nil {
 		log.Println("Sync client failed to initialize.")
-		return;
+		return
 	}
 
 	// Message channel.
@@ -403,33 +404,28 @@ func getServiceConfig() map[string]map[string]string {
 			"syncDBProvider":       env.GetEnv("SYNC_DATABASE_PROVIDER", "local"),
 			"messageProvider":      env.GetEnv("SYNC_MESSAGE_PROVIDER", "local"),
 		},
-		"message":
-		{
+		"message": {
 			"forceSync":  strings.ToLower(env.GetEnv("SYNC_FORCE_AUDITS", "no")),
 			"apiClient":  env.GetEnv("SYNC_DEFAULT_CLIENT", "wporg"),
 			"visibility": env.GetEnv("SYNC_DEFAULT_VISIBILITY", "public"),
 		},
-		"local":
-		{
+		"local": {
 			"dbPath": env.GetEnv("SYNC_DATA", "./db"),
 		},
-		"aws":
-		{
+		"aws": {
 			"key":             env.GetEnv("AWS_API_KEY", ""),
 			"secret":          env.GetEnv("AWS_API_SECRET", ""),
 			"sqs_region":      env.GetEnv("AWS_SQS_REGION", ""),
 			"sqs_lh_queue":    env.GetEnv("AWS_SQS_QUEUE_LH", ""),
 			"sqs_phpcs_queue": env.GetEnv("AWS_SQS_QUEUE_PHPCS", ""),
 		},
-		"gcp":
-		{
+		"gcp": {
 			"projectID":            env.GetEnv("GCP_PROJECT", ""),
 			"docPath":              env.GetEnv("SYNC_DATABASE_DOCUMENT_PATH", "sync-server/wporg"),
 			"lighthouseCollection": env.GetEnv("GCF_QUEUE_LH", "queue-lighthouse"),
 			"phpcsCollection":      env.GetEnv("GCF_QUEUE_PHPCS", "queue-phpcs"),
 		},
-		"mongo":
-		{
+		"mongo": {
 			"user":                 env.GetEnv("MONGO_DATABASE_USERNAME", ""),
 			"pass":                 env.GetEnv("MONGO_DATABASE_PASSWORD", ""),
 			"host":                 "localhost:27017",
@@ -437,8 +433,7 @@ func getServiceConfig() map[string]map[string]string {
 			"lighthouseCollection": env.GetEnv("MONGO_QUEUE_LH", "lighthouse"),
 			"phpcsCollection":      env.GetEnv("MONGO_QUEUE_PHPCS", "phpcs"),
 		},
-		"tide":
-		{
+		"tide": {
 			"host":     env.GetEnv("API_HTTP_HOST", "wptide.org"),
 			"protocol": env.GetEnv("API_PROTOCOL", "https"),
 			"version":  env.GetEnv("API_VERSION", "v1"),

--- a/cmd/sync-server/main.go
+++ b/cmd/sync-server/main.go
@@ -59,7 +59,7 @@ func fetcher(projectType, category string, bufferSize int, token chan struct{}, 
 		// Don't do anything until a token is available.
 		<-token
 
-		var response *wporg.ApiResponse
+		var response *wporg.APIResponse
 		var err error
 
 		for {
@@ -151,7 +151,7 @@ func fetcher(projectType, category string, bufferSize int, token chan struct{}, 
 
 // pool starts a number of infoWorkers. This uses a "worker" pattern where each worker will
 // read from a projects channel to process the results.
-func pool(workers int, projects <-chan wporg.RepoProject, checker sync.UpdateChecker, dispatcher sync.Dispatcher, messages chan *message.Message) {
+func pool(workers int, projects <-chan wporg.RepoProject, checker sync.Updater, dispatcher sync.Dispatcher, messages chan *message.Message) {
 	for i := 0; i < workers; i++ {
 		go infoWorker(projects, checker, dispatcher, messages)
 	}
@@ -159,7 +159,7 @@ func pool(workers int, projects <-chan wporg.RepoProject, checker sync.UpdateChe
 
 // infoWorker reads a project from the projects channel, runs it through the update check
 // and (conditionally) sends it to the dispatcher which loads up the job queue.
-func infoWorker(projects <-chan wporg.RepoProject, checker sync.UpdateChecker, dispatcher sync.Dispatcher, messages chan *message.Message) {
+func infoWorker(projects <-chan wporg.RepoProject, checker sync.Updater, dispatcher sync.Dispatcher, messages chan *message.Message) {
 	for {
 		select {
 		case project := <-projects:
@@ -216,7 +216,7 @@ func timeAfterEqual(project wporg.RepoProject, t time.Time, format string) bool 
 }
 
 // mostRecentFromResponse returns the most recent project from the response.
-func mostRecentFromResponse(response *wporg.ApiResponse) *wporg.RepoProject {
+func mostRecentFromResponse(response *wporg.APIResponse) *wporg.RepoProject {
 	var mostRecent *wporg.RepoProject
 
 	if len(response.Themes) > 0 {
@@ -316,7 +316,7 @@ func getDispatcher(c map[string]map[string]string) (sync.Dispatcher, error) {
 					"themes",
 				},
 			},
-			providers: make(map[string]message.MessageProvider),
+			providers: make(map[string]message.Provider),
 		}, nil
 	case "firestore":
 		conf := c["gcp"]
@@ -339,7 +339,7 @@ func getDispatcher(c map[string]map[string]string) (sync.Dispatcher, error) {
 					"themes",
 				},
 			},
-			providers: make(map[string]message.MessageProvider),
+			providers: make(map[string]message.Provider),
 		}, nil
 	case "local":
 		conf := c["mongo"]
@@ -367,14 +367,14 @@ func getDispatcher(c map[string]map[string]string) (sync.Dispatcher, error) {
 					"themes",
 				},
 			},
-			providers: make(map[string]message.MessageProvider),
+			providers: make(map[string]message.Provider),
 		}, nil
 	default:
 		return nil, nil
 	}
 }
 
-func getSyncProvider(c map[string]map[string]string) (sync.UpdateSyncChecker, error) {
+func getSyncProvider(c map[string]map[string]string) (sync.UpdateChecker, error) {
 	switch c["app"]["syncDBProvider"] {
 	case "local":
 		conf := c["local"]

--- a/cmd/sync-server/main_test.go
+++ b/cmd/sync-server/main_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/wptide/pkg/wporg"
 )
 
-var mockThemesApi = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+var mockThemesAPI = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	bodyByte, _ := ioutil.ReadAll(r.Body)
 	parts := strings.Split(string(bodyByte), "&")
 
@@ -47,13 +47,12 @@ var mockThemesApi = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWrit
 			return
 		case "request[browse]=fail":
 			panic("failed!")
-			return
 		}
 	}
 	fmt.Fprintln(w, `invalid`)
 }))
 
-var mockPluginsApi = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+var mockPluginsAPI = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	bodyByte, _ := ioutil.ReadAll(r.Body)
 	parts := strings.Split(string(bodyByte), "&")
 
@@ -153,8 +152,8 @@ func Test_fetcher(t *testing.T) {
 				-1,
 			},
 			sources{
-				mockPluginsApi.URL,
-				mockThemesApi.URL,
+				mockPluginsAPI.URL,
+				mockThemesAPI.URL,
 			},
 			reflect.TypeOf(make(<-chan wporg.RepoProject)),
 			mockChecker{},
@@ -169,8 +168,8 @@ func Test_fetcher(t *testing.T) {
 				-1,
 			},
 			sources{
-				mockPluginsApi.URL,
-				mockThemesApi.URL,
+				mockPluginsAPI.URL,
+				mockThemesAPI.URL,
 			},
 			reflect.TypeOf(make(<-chan wporg.RepoProject)),
 			mockChecker{},
@@ -185,8 +184,8 @@ func Test_fetcher(t *testing.T) {
 				2,
 			},
 			sources{
-				mockPluginsApi.URL,
-				mockThemesApi.URL,
+				mockPluginsAPI.URL,
+				mockThemesAPI.URL,
 			},
 			reflect.TypeOf(make(<-chan wporg.RepoProject)),
 			mockChecker{},
@@ -201,8 +200,8 @@ func Test_fetcher(t *testing.T) {
 				-1,
 			},
 			sources{
-				mockPluginsApi.URL,
-				mockThemesApi.URL,
+				mockPluginsAPI.URL,
+				mockThemesAPI.URL,
 			},
 			reflect.TypeOf(make(<-chan wporg.RepoProject)),
 			mockChecker{},
@@ -217,8 +216,8 @@ func Test_fetcher(t *testing.T) {
 				-1,
 			},
 			sources{
-				mockPluginsApi.URL,
-				mockThemesApi.URL,
+				mockPluginsAPI.URL,
+				mockThemesAPI.URL,
 			},
 			reflect.TypeOf(make(<-chan wporg.RepoProject)),
 			nil,
@@ -547,8 +546,7 @@ func Test_getDispatcher(t *testing.T) {
 						"syncLighthouseActive": "on",
 						"messageProvider":      "firestore",
 					},
-					"gcp":
-					{
+					"gcp": {
 						"projectID":            "fake-id",
 						"docPath":              "doc",
 						"lighthouseCollection": "fake-lh",
@@ -568,8 +566,7 @@ func Test_getDispatcher(t *testing.T) {
 						"syncLighthouseActive": "on",
 						"messageProvider":      "sqs",
 					},
-					"aws":
-					{
+					"aws": {
 						"key":             "abc",
 						"secret":          "def",
 						"sqs_region":      "us-west-2",
@@ -590,12 +587,11 @@ func Test_getDispatcher(t *testing.T) {
 						"syncLighthouseActive": "on",
 						"messageProvider":      "local",
 					},
-					"mongo":
-					{
-						"user": "",
-						"pass": "",
-						"host": "localhost:12345",
-						"database": "queue",
+					"mongo": {
+						"user":                 "",
+						"pass":                 "",
+						"host":                 "localhost:12345",
+						"database":             "queue",
 						"lighthouseCollection": "fake-lh",
 						"phpcsCollection":      "fake-phpcs",
 					},

--- a/cmd/sync-server/main_test.go
+++ b/cmd/sync-server/main_test.go
@@ -140,7 +140,7 @@ func Test_fetcher(t *testing.T) {
 		args    args
 		sources sources
 		want    reflect.Type
-		checker sync.UpdateSyncChecker
+		checker sync.UpdateChecker
 	}{
 		{
 			"Themes",
@@ -226,8 +226,8 @@ func Test_fetcher(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set mock sources.
-			client.SetPluginApiSource(tt.sources.plugins)
-			client.SetThemeApiSource(tt.sources.themes)
+			client.SetPluginAPISource(tt.sources.plugins)
+			client.SetThemeAPISource(tt.sources.themes)
 
 			if tt.checker != nil {
 				oldChecker := checker
@@ -293,7 +293,7 @@ func Test_infoWorker(t *testing.T) {
 
 	type args struct {
 		project    wporg.RepoProject
-		checker    sync.UpdateChecker
+		checker    sync.Updater
 		dispatcher sync.Dispatcher
 		messages   chan *message.Message
 	}
@@ -346,7 +346,7 @@ func Test_pool(t *testing.T) {
 	type args struct {
 		workers    int
 		project    wporg.RepoProject
-		checker    sync.UpdateChecker
+		checker    sync.Updater
 		dispatcher sync.Dispatcher
 		messages   chan *message.Message
 	}
@@ -515,7 +515,7 @@ func Test_getSyncProvider(t *testing.T) {
 					},
 				},
 			},
-			reflect.TypeOf(&firestore.FirestoreSync{}),
+			reflect.TypeOf(&firestore.Sync{}),
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/sync-server/mock_test.go
+++ b/cmd/sync-server/mock_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+
 	"github.com/wptide/pkg/message"
 )
 

--- a/cmd/sync-server/mongo.go
+++ b/cmd/sync-server/mongo.go
@@ -1,18 +1,19 @@
 package main
 
 import (
-	"github.com/wptide/pkg/wporg"
-	"github.com/wptide/pkg/message"
 	"context"
 	"errors"
+
+	"github.com/wptide/pkg/message"
 	"github.com/wptide/pkg/message/mongo"
+	"github.com/wptide/pkg/wporg"
 )
 
 type mongoDispatcher struct {
-	ctx context.Context
-	user string
-	pass string
-	host string
+	ctx      context.Context
+	user     string
+	pass     string
+	host     string
 	database string
 
 	Collections map[string]struct {
@@ -29,8 +30,8 @@ func (m mongoDispatcher) Dispatch(project wporg.RepoProject) error {
 
 	for collectionID, collection := range m.Collections {
 		queueProvider, ok := m.providers[collectionID]
-		if ! ok {
-			return errors.New("Could not access queue. Make sure the dispatcher is initialised.")
+		if !ok {
+			return errors.New("could not access queue: make sure the dispatcher is initialised")
 		}
 		if collection.Active && (collection.Accepts == project.Type || collection.Accepts == "all") {
 			err := queueProvider.SendMessage(msg)
@@ -46,7 +47,7 @@ func (m mongoDispatcher) Dispatch(project wporg.RepoProject) error {
 func (m *mongoDispatcher) Init() error {
 	for collectionID, collection := range m.Collections {
 		messageProvider, ok := m.providers[collectionID]
-		if ! ok {
+		if !ok {
 			messageProvider, _ = mongo.New(m.ctx, m.user, m.pass, m.host, m.database, collection.Collection, nil)
 			m.providers[collectionID] = messageProvider
 		}
@@ -55,7 +56,7 @@ func (m *mongoDispatcher) Init() error {
 }
 
 func (m *mongoDispatcher) Close() error {
-	for collectionID, _ := range m.Collections {
+	for collectionID := range m.Collections {
 		messageProvider, ok := m.providers[collectionID]
 		if ok {
 			messageProvider.Close()

--- a/cmd/sync-server/mongo.go
+++ b/cmd/sync-server/mongo.go
@@ -21,7 +21,7 @@ type mongoDispatcher struct {
 		Active     bool
 		Accepts    string // "all" or "themes" or "plugins"
 	}
-	providers map[string]message.MessageProvider
+	providers map[string]message.Provider
 }
 
 func (m mongoDispatcher) Dispatch(project wporg.RepoProject) error {

--- a/cmd/sync-server/mongo_test.go
+++ b/cmd/sync-server/mongo_test.go
@@ -38,7 +38,7 @@ var (
 )
 
 func initMockMongoProviders(m mongoDispatcher) {
-	for collectionID, _ := range m.Collections {
+	for collectionID := range m.Collections {
 		queueProvider, ok := m.providers[collectionID]
 		if !ok {
 			queueProvider = &mockProvider{}

--- a/cmd/sync-server/mongo_test.go
+++ b/cmd/sync-server/mongo_test.go
@@ -59,7 +59,7 @@ func Test_mongoDispatcher_Dispatch(t *testing.T) {
 			Active     bool
 			Accepts    string
 		}
-		providers map[string]message.MessageProvider
+		providers map[string]message.Provider
 	}
 	type args struct {
 		project wporg.RepoProject
@@ -80,7 +80,7 @@ func Test_mongoDispatcher_Dispatch(t *testing.T) {
 				"mock-host:1234",
 				"test-queue",
 				mongoCollections,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			args{
 				wporg.RepoProject{
@@ -99,7 +99,7 @@ func Test_mongoDispatcher_Dispatch(t *testing.T) {
 				"mock-host:1234",
 				"test-queue",
 				mongoCollections,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			args{
 				wporg.RepoProject{
@@ -118,7 +118,7 @@ func Test_mongoDispatcher_Dispatch(t *testing.T) {
 				"mock-host:1234",
 				"test-queue",
 				mongoCollections,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			args{
 				wporg.RepoProject{
@@ -137,7 +137,7 @@ func Test_mongoDispatcher_Dispatch(t *testing.T) {
 				"mock-host:1234",
 				"test-queue",
 				mongoCollections,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			args{
 				wporg.RepoProject{
@@ -184,7 +184,7 @@ func Test_mongoDispatcher_Init(t *testing.T) {
 			Active     bool
 			Accepts    string
 		}
-		providers map[string]message.MessageProvider
+		providers map[string]message.Provider
 	}
 	tests := []struct {
 		name    string
@@ -200,7 +200,7 @@ func Test_mongoDispatcher_Init(t *testing.T) {
 				"mock-host:1234",
 				"test-queue",
 				mongoCollections,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			false,
 		}}
@@ -234,7 +234,7 @@ func Test_mongoDispatcher_Close(t *testing.T) {
 			Active     bool
 			Accepts    string
 		}
-		providers map[string]message.MessageProvider
+		providers map[string]message.Provider
 	}
 	tests := []struct {
 		name    string
@@ -250,7 +250,7 @@ func Test_mongoDispatcher_Close(t *testing.T) {
 				"localhost:27017",
 				"mock-db",
 				mongoCollections,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			false,
 		},

--- a/cmd/sync-server/sqs.go
+++ b/cmd/sync-server/sqs.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/wptide/pkg/message"
-	"github.com/wptide/pkg/wporg"
-	"github.com/wptide/pkg/message/sqs"
 	"errors"
+
+	"github.com/wptide/pkg/message"
+	"github.com/wptide/pkg/message/sqs"
+	"github.com/wptide/pkg/wporg"
 )
 
 type sqsDispatcher struct {
@@ -27,8 +28,8 @@ func (s sqsDispatcher) Dispatch(project wporg.RepoProject) error {
 	for queueID, queue := range s.Queues {
 
 		queueProvider, ok := s.providers[queueID]
-		if ! ok {
-			return errors.New("Could not access queue. Make sure the dispatcher is initialised.")
+		if !ok {
+			return errors.New("could not access queue: make sure the dispatcher is initialised")
 		}
 
 		if queue.Active && (queue.Accepts == project.Type || queue.Accepts == "all") {
@@ -45,7 +46,7 @@ func (s sqsDispatcher) Dispatch(project wporg.RepoProject) error {
 func (s *sqsDispatcher) Init() error {
 	for queueID, queue := range s.Queues {
 		queueProvider, ok := s.providers[queueID]
-		if ! ok {
+		if !ok {
 			queueProvider = sqs.NewSqsProvider(queue.Region, queue.Key, queue.Secret, queue.Queue)
 			s.providers[queueID] = queueProvider
 		}
@@ -54,7 +55,7 @@ func (s *sqsDispatcher) Init() error {
 }
 
 func (s *sqsDispatcher) Close() error {
-	for queueID, _ := range s.Queues {
+	for queueID := range s.Queues {
 		queueProvider, ok := s.providers[queueID]
 		if ok {
 			queueProvider.Close()

--- a/cmd/sync-server/sqs.go
+++ b/cmd/sync-server/sqs.go
@@ -18,7 +18,7 @@ type sqsDispatcher struct {
 		Active   bool
 		Accepts  string // "all" or "themes" or "plugins"
 	}
-	providers map[string]message.MessageProvider
+	providers map[string]message.Provider
 }
 
 func (s sqsDispatcher) Dispatch(project wporg.RepoProject) error {

--- a/cmd/sync-server/sqs_test.go
+++ b/cmd/sync-server/sqs_test.go
@@ -84,7 +84,7 @@ func Test_sqsDispatcher_Dispatch(t *testing.T) {
 			Active   bool
 			Accepts  string
 		}
-		providers map[string]message.MessageProvider
+		providers map[string]message.Provider
 	}
 	type args struct {
 		project wporg.RepoProject
@@ -100,7 +100,7 @@ func Test_sqsDispatcher_Dispatch(t *testing.T) {
 			"Theme Project",
 			fields{
 				testQueues,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			args{
 				wporg.RepoProject{
@@ -114,7 +114,7 @@ func Test_sqsDispatcher_Dispatch(t *testing.T) {
 			"Plugin Project",
 			fields{
 				testQueues,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			args{
 				wporg.RepoProject{
@@ -128,7 +128,7 @@ func Test_sqsDispatcher_Dispatch(t *testing.T) {
 			"Theme Project - No Init()",
 			fields{
 				testQueues,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			args{
 				wporg.RepoProject{
@@ -142,7 +142,7 @@ func Test_sqsDispatcher_Dispatch(t *testing.T) {
 			"Theme Project - Provider Fail",
 			fields{
 				testQueues,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			args{
 				wporg.RepoProject{
@@ -183,7 +183,7 @@ func Test_sqsDispatcher_Init(t *testing.T) {
 			Active   bool
 			Accepts  string
 		}
-		providers map[string]message.MessageProvider
+		providers map[string]message.Provider
 	}
 	tests := []struct {
 		name    string
@@ -194,7 +194,7 @@ func Test_sqsDispatcher_Init(t *testing.T) {
 			"Init Providers",
 			fields{
 				testQueues,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			false,
 		},
@@ -223,7 +223,7 @@ func Test_sqsDispatcher_Close(t *testing.T) {
 			Active   bool
 			Accepts  string
 		}
-		providers map[string]message.MessageProvider
+		providers map[string]message.Provider
 	}
 	tests := []struct {
 		name    string
@@ -234,7 +234,7 @@ func Test_sqsDispatcher_Close(t *testing.T) {
 			"Close with collections",
 			fields{
 				testQueues,
-				make(map[string]message.MessageProvider),
+				make(map[string]message.Provider),
 			},
 			false,
 		},

--- a/cmd/sync-server/sqs_test.go
+++ b/cmd/sync-server/sqs_test.go
@@ -59,7 +59,7 @@ var (
 )
 
 func initMockProviders(s *sqsDispatcher) {
-	for queueID, _ := range s.Queues {
+	for queueID := range s.Queues {
 		queueProvider, ok := s.providers[queueID]
 		if !ok {
 			queueProvider = &mockProvider{}

--- a/glide.lock
+++ b/glide.lock
@@ -112,7 +112,7 @@ imports:
 - name: github.com/toqueteos/trie
   version: 56fed4a05683322f125e2d78ee269bb102280392
 - name: github.com/wptide/pkg
-  version: aebc2f7c0993d9f1c105eed4a343d7965da377da
+  version: 016dfcb8675051b3f6794de764f7abedfe6a4f36
   subpackages:
   - env
   - log

--- a/glide.lock
+++ b/glide.lock
@@ -112,7 +112,7 @@ imports:
 - name: github.com/toqueteos/trie
   version: 56fed4a05683322f125e2d78ee269bb102280392
 - name: github.com/wptide/pkg
-  version: 05f3be7becfadf5255fdf0f57ac678a50c5ada7b
+  version: aebc2f7c0993d9f1c105eed4a343d7965da377da
   subpackages:
   - env
   - log

--- a/glide.lock
+++ b/glide.lock
@@ -112,7 +112,7 @@ imports:
 - name: github.com/toqueteos/trie
   version: 56fed4a05683322f125e2d78ee269bb102280392
 - name: github.com/wptide/pkg
-  version: 016dfcb8675051b3f6794de764f7abedfe6a4f36
+  version: 50ca90d9e6882d732c6b8d9f6211f0e667b5fc6f
   subpackages:
   - env
   - log


### PR DESCRIPTION
### Description of the Change

This PR runs all the Go code through `gofmt` to ensure recommended Go formatting.

Code has also been run through `govet` and `golint` and fixed accordingly.

e.g.
- dropping 2nd argument in ranges where not required
- removing else blocks where the true condition is a `return`
- removing capitals and punctuation from error messages

### Alternate Designs

We could keep things the way they are, but ideally we would write Go code the Go way.

### Benefits

Promoting the adoption of standards regardless the language.

### Possible Drawbacks

Getting use to lowercase error messages ;)

### Verification Process

`make test`, `govet` and `golint` passes.

### Applicable Issues

New issue.
