### PR TITLE
Set some defaults and cache key salt

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -2,14 +2,15 @@
 #-- API ---------------------------------------------------------
 #----------------------------------------------------------------
 
-API_ADMIN_EMAIL=<CHANGE_THIS_VALUE>
-API_ADMIN_PASSWORD=<CHANGE_THIS_VALUE>
-API_ADMIN_USER=<CHANGE_THIS_VALUE>
+API_ADMIN_EMAIL=admin@tide.local
+API_ADMIN_PASSWORD=wordpress
+API_ADMIN_USER=admin
 API_AUTH_URL=http://tide.local/api/tide/v1/auth
 API_BLOG_DESCRIPTION=Automated insight into your WordPress code
 API_BLOG_NAME=Tide
 API_CACHE=true
 API_CACHE_DEBUG=false
+API_CACHE_KEY_SALT=xbIm5y$i&mM#W9q93la#x*qoE0cvbjWxDTFq@4r3nHJc*ZcIiW@pI@2z$GC7BEz7
 API_CACHE_TTL=86400
 API_DB_HOST=api-mysql
 API_DB_NAME=wordpress
@@ -17,14 +18,14 @@ API_DB_PASSWORD=wordpress
 API_DB_ROOT_PASSWORD=wordpress
 API_DB_USER=wordpress
 API_HTTP_HOST=tide.local
-API_KEY=<CHANGE_THIS_VALUE>
+API_KEY=uRhZgeYt$v5u0vR5fpcDSWcZU
 API_MESSAGE_PROVIDER=local
 API_PROTOCOL=http
 API_REDIS_AUTH=redis
 API_REDIS_DATABASE=0
 API_REDIS_HOST=api-redis
 API_REDIS_PORT=6379
-API_SECRET=<CHANGE_THIS_VALUE>
+API_SECRET=rVvUWQlPQr8trSEd2qdwmE4Eiua$MjLX
 API_THEME=twentyseventeen
 API_UPLOAD_HANDLER=local
 API_VERSION=v1

--- a/README.md
+++ b/README.md
@@ -251,14 +251,15 @@ from the `audit-server` user profile.
 
 | Variable | Description |
 | :--- | :--- |
-| `API_ADMIN_EMAIL` | The email associated with the local admin account. |
-| `API_ADMIN_PASSWORD` | The password associated with the local admin account. |
-| `API_ADMIN_USER` | The username associated with the local admin account. |
+| `API_ADMIN_EMAIL` | The email associated with the local admin account. Default is `admin@tide.local`. |
+| `API_ADMIN_PASSWORD` | The password associated with the local admin account. Default is `wordpress`. |
+| `API_ADMIN_USER` | The username associated with the local admin account. Default is `admin`. |
 | `API_AUTH_URL` | The [`wp-tide-api`][wp-tide-api] authentication REST endpoint, used both locally and on GCP. Default is `http://tide.local/api/tide/v1/auth`. |
 | `API_BLOG_DESCRIPTION` | Site tagline (set in Settings > General). Default is `Automated insight into your WordPress code`. |
 | `API_BLOG_NAME` | Site title (set in Settings > General). Default is `Tide`. |
 | `API_CACHE` | Whether caching should be active or not. Must be one of: `true`, `false`. Default is `true`. |
 | `API_CACHE_DEBUG` | Whether or not to display the caching headers for debugging. Must be one of: `true`, `false`. Default is `false`. |
+| `API_CACHE_KEY_SALT` | Set the cache key salt which Redis relies on to build the cache. This should be a random 64 character string. Default is `xbIm5y$i&mM#W9q93la#x*qoE0cvbjWxDTFq@4r3nHJc*ZcIiW@pI@2z$GC7BEz7`. This value should be updated in production. |
 | `API_CACHE_TTL` | Sets the numeric time to live (TTL) in seconds for page caching. Default is `300`. |
 | `API_DB_HOST` | The host of the local database, which connects to a Docker container. Default is `api-mysql`. |
 | `API_DB_NAME` | Name of the local database. Default is `wordpress`. |
@@ -266,14 +267,14 @@ from the `audit-server` user profile.
 | `API_DB_ROOT_PASSWORD` | The local database root password. Default is `wordpress`. |
 | `API_DB_USER` | Username used to access the local database. Default is `wordpress`. |
 | `API_HTTP_HOST` | The API domain name, used both locally and on GCP. Default is `tide.local`. |
-| `API_KEY` | The API key used locally to authenticate the `audit-server` user. |
+| `API_KEY` | The API key used locally to authenticate the `audit-server` user. Default is `uRhZgeYt$v5u0vR5fpcDSWcZU`. Change this in production. |
 | `API_MESSAGE_PROVIDER` | Queue audit messages using the local MongoDB, Google Cloud Firestore, or AWS SQS. Must be one of: `local`, `firestore`, `sqs`. Default is `local`. |
 | `API_PROTOCOL` | The API protocol, used both locally and on GCP Default is `http`. |
 | `API_REDIS_AUTH` | The Redis database password. Default is `redis`. |
 | `API_REDIS_DATABASE` | Use a specific numeric Redis database. Default is `0`. |
 | `API_REDIS_HOST` | The host where the Redis database can be reached. Default is `api-redis`. |
 | `API_REDIS_PORT` | The port where the Redis database can be reached. Default is `6379`. |
-| `API_SECRET` | The API secret used locally to authenticate the `audit-server` user. |
+| `API_SECRET` | The API secret used locally to authenticate the `audit-server` user. Default is `rVvUWQlPQr8trSEd2qdwmE4Eiua$MjLX`. Change this in production. |
 | `API_THEME` | The slug of the local WordPress theme. Default is `twentyseventeen`. |
 | `API_UPLOAD_HANDLER` | Tells WordPress how media upload is handled. Uses either the local file system or Google Cloud Storage. Must be one of: `local`, `gcs`. Default is `local`. |
 | `API_VERSION` | The API version found in the Tide API REST url, used both locally and on GCP. Default is `v1`. |

--- a/bin/tpl
+++ b/bin/tpl
@@ -100,7 +100,6 @@ uniqueKeys=(
     SECURE_AUTH_SALT
     LOGGED_IN_SALT
     NONCE_SALT
-    CACHE_KEY_SALT
 )
 
 ## Export the unique Keys and Salts.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
             API_BLOG_DESCRIPTION: ${API_BLOG_DESCRIPTION}
             API_BLOG_NAME: ${API_BLOG_NAME}
             API_CACHE_DEBUG: ${API_CACHE_DEBUG}
+            API_CACHE_KEY_SALT: ${API_CACHE_KEY_SALT}
             API_CACHE_TTL: ${API_CACHE_TTL}
             API_DB_HOST: ${API_DB_HOST}
             API_DB_NAME: ${API_DB_NAME}

--- a/service/api/tpl/wp-config.tpl
+++ b/service/api/tpl/wp-config.tpl
@@ -109,7 +109,7 @@ $table_prefix  = 'wp_';
  * Page and Object caching are both backed by Redis.
  */
 define( 'WP_CACHE',          ${API_CACHE} );
-define( 'WP_CACHE_KEY_SALT', '${CACHE_KEY_SALT}' );
+define( 'WP_CACHE_KEY_SALT', '${API_CACHE_KEY_SALT}' );
 
 // Redis settings.
 if ( true === WP_CACHE ) {


### PR DESCRIPTION
Made the local setup easier and added a way to set the cache key salt so Redis doesn't loose the cache in production on each deployment.