### PR TITLE
Remove :ro from WP volumes in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,10 @@ services:
             - ./service/api:/app
             - ./service/api/nginx-app.conf:/etc/nginx/conf.d/nginx-app.conf
             - ./service/api/php.ini:/opt/php72/lib/php.ini
-            - ./service/api/wp-content:/app/wordpress/wp-content:ro
+            - ./service/api/wp-content:/app/wordpress/wp-content
             - ./service-account.json:/srv/service-account.json:ro
-            - ./data/lighthouse-server:/app/wordpress/wp-content/uploads/lighthouse:ro
-            - ./data/phpcs-server:/app/wordpress/wp-content/uploads/phpcs:ro
+            - ./data/lighthouse-server:/app/wordpress/wp-content/uploads/lighthouse
+            - ./data/phpcs-server:/app/wordpress/wp-content/uploads/phpcs
         depends_on:
             - api-mysql
             - api-redis


### PR DESCRIPTION
### Description of the Change

Bugfix:

WP volumes were set `:ro` in docker-compose.yml causing `make api.up` to fail.

This PR removes the flag on those volumes.

### Verification Process

`make api.up` and `make up` and `make build.up` works again.
 
### Applicable Issues

New issue.