### PR TITLE
Change info after setup to edit /ets/hosts

### DIFF
--- a/service/api/setup.sh
+++ b/service/api/setup.sh
@@ -95,6 +95,6 @@ echo
 echo "Be sure to add '${BOLD}127.0.0.1 ${API_HTTP_HOST}${RESET}' to your hosts file."
 echo "Use the following command (${RED}with caution${RESET}):"
 echo
-echo "${YELLOW}sudo echo \"127.0.0.1 ${API_HTTP_HOST}\" >> /private/etc/hosts${RESET}"
+echo "${YELLOW}sudo echo \"127.0.0.1 ${API_HTTP_HOST}\" >> /etc/hosts${RESET}"
 echo
 exit 0


### PR DESCRIPTION
### Requirements

### Description of the Change

/etc/hosts exist on both Linux and on macOS, where /etc is symlinked to /private/etc

### Alternate Designs

/private/etc/hosts does not exist on Linux

### Benefits

Right thing to suggest to Linux developer

### Possible Drawbacks

None - it is an info message change

### Verification Process

Installed on Ubuntu. Setup instructed to edit /private/etc/hosts which is not the right location

### Applicable Issues

None.