### PR TITLE
Set WP_DEBUG_LOG to true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ service/api/wp-content/themes
 !service/api/wp-content/themes/docs
 service/api/wp-content/uploads
 service/api/wp-content/upgrade
+service/api/wp-content/debug.log
 service/api/app.yaml
 service/api/cron.yaml
 service/api/wp-config.php

--- a/service/api/tpl/wp-config.tpl
+++ b/service/api/tpl/wp-config.tpl
@@ -154,7 +154,7 @@ if ( true === WP_CACHE ) {
  * @link https://codex.wordpress.org/Debugging_in_WordPress
  */
 define( 'WP_DEBUG', ! $is_gae );
-define( 'WP_DEBUG_LOG', true );
+define( 'WP_DEBUG_LOG', ! $is_gae );
 
 // API configuration settings.
 define( 'API_MESSAGE_PROVIDER', getenv( 'API_MESSAGE_PROVIDER' ) );

--- a/service/api/tpl/wp-config.tpl
+++ b/service/api/tpl/wp-config.tpl
@@ -154,6 +154,7 @@ if ( true === WP_CACHE ) {
  * @link https://codex.wordpress.org/Debugging_in_WordPress
  */
 define( 'WP_DEBUG', ! $is_gae );
+define( 'WP_DEBUG_LOG', true );
 
 // API configuration settings.
 define( 'API_MESSAGE_PROVIDER', getenv( 'API_MESSAGE_PROVIDER' ) );


### PR DESCRIPTION
The `debug.log` file will only be created when WP_DEBUG is true so it will not be created in production.