### PR TITLE
Update PHP_CodeSniffer version to 3.3.1

### DIFF
--- a/service/phpcs-server/docker/Dockerfile
+++ b/service/phpcs-server/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN set -x \
         php7-phar \
     && curl -Lo /usr/local/bin/composer https://getcomposer.org/composer.phar \
     && chmod +x /usr/local/bin/composer \
-    && composer global require squizlabs/php_codesniffer:3.2.3 \
+    && composer global require squizlabs/php_codesniffer:3.3.1 \
     && composer global require wp-coding-standards/wpcs:0.14.1 \
     && composer global require wimg/php-compatibility:dev-master \
     && $VENDOR/bin/phpcs --config-set show_progress 1 \


### PR DESCRIPTION
### Requirements
This PR fix #116 

### Description of the Change
The new version 3.3.1 of PHP_CodeSniffer has been released. The intention of this PR was to keep the wptide's PHPCS version up-to-date with it's latest version.

### Verification Process
This PR was not tested.

### Applicable Issues
#116 
