### PR TITLE
Fix a typo in readme's Table of Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ quality in the developer consciousness. **Because a rising Tide lifts all boats.
    + [Introduction](#introduction)
    + [Dependencies](#dependencies)
    + [Cloning](#cloning)
-   + [Setup]($setup)
+   + [Setup](#setup)
        - [Environment Variables](#environment-variables)
        - [Google Cloud SDK](#google-cloud-sdk)
        - [Google App Engine](#google-app-engine)


### PR DESCRIPTION
### Description of the Change
Self-explainable. Clicking on "Setup" in Table of Contents links to 404 page at the moment, since GitHub thinks that it's a file.