### PR TITLE
Update pkg & images

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -112,7 +112,7 @@ imports:
 - name: github.com/toqueteos/trie
   version: 56fed4a05683322f125e2d78ee269bb102280392
 - name: github.com/wptide/pkg
-  version: e041a675659d9398ded5b33bbf52ebd168e94305
+  version: 6b11b6f8980648f4f8255f9de78ddf2f19a80c7d
   subpackages:
   - env
   - log

--- a/service/lighthouse-server/docker/Dockerfile
+++ b/service/lighthouse-server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM node:alpine
 
 MAINTAINER XWP <engage@xwp.co>
 

--- a/service/phpcs-server/docker/Dockerfile
+++ b/service/phpcs-server/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 MAINTAINER XWP <engage@xwp.co>
 

--- a/service/phpcs-server/docker/Dockerfile
+++ b/service/phpcs-server/docker/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER XWP <engage@xwp.co>
 ENV VENDOR                   /root/.composer/vendor
 ENV PHPCS                    3.4.2
 ENV WPCS                     2.1.1
-ENV PHPCOMPAT                9.1.1
+ENV PHPCOMPAT                9.2.0
 ENV PHPCOMPAT_WP             2.0.0
 ENV PHPCOMPAT_PASSWORDCOMPAT 1.0.0
 ENV PHPCOMPAT_PARAGONIE      1.0.1


### PR DESCRIPTION
Updated the reference to `pkg` after the PR merge, which forced an image rebuild for the Lighthouse Server which failed to audit plugins/themes because it required Node 10+ to use Lighthouse 5+, so the image is now being built from alpine node:12 running Lighthouse 5.2 and Chromium 72 instead of 68 for alpine. 

I also updated the PHP Compatibility version to 9.2.0 and everything is working as expected. I will deploy to production after this is merged.