### PR TITLE
Exclude the 'data' directory when Glide scans for dependencies

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,6 @@
 package: github.com/wptide/wptide
+excludeDirs:
+- data
 import:
 - package: github.com/nanobox-io/golang-scribble
 - package: github.com/wptide/pkg


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
By default, Glide scans all directories for dependencies. Some files in the 'data' directory is owned by the `root` user (due to the Docker containers), and Glide cannot open these files to scan for dependencies.

This PR adds the 'data' directory to be excluded.

### Benefits

<!-- What benefits will be realized by the code change? -->
Glide's dependency scanning should be quicker.