### PR TITLE
Get PHPCS versions from environment and pass to PHPCS process

### DIFF
--- a/cmd/phpcs-server/main.go
+++ b/cmd/phpcs-server/main.go
@@ -265,6 +265,7 @@ func processMessage(msg message.Message, wg *sync.WaitGroup) error {
 		TempFolder:      procCfg.phpcsTempFolder,
 		Config:          config,
 		StorageProvider: procCfg.phpcsStorageProvider,
+		Versions:        serviceConfig["phpcs_versions"],
 	}
 	if err := doPHPCSProcess(phpcsProc, msg, results); err != nil {
 		return err
@@ -463,6 +464,10 @@ func getServiceConfig() map[string]map[string]string {
 			"host":     env.GetEnv("API_HTTP_HOST", ""),
 			"protocol": env.GetEnv("API_PROTOCOL", ""),
 			"version":  env.GetEnv("API_VERSION", ""),
+		},
+		"phpcs_versions": {
+			"phpcompatibility": env.GetEnv("PHPCS", ""),
+			"wordpress":        env.GetEnv("WPCS", ""),
 		},
 	}
 }


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR retrieves PHPCS versions from the environment and passes them as a mapping to the PHPCS process.

### Verification Process

Manual testing was done to verify the API returns the PHPCS version, and that the `audit` post type contains the PHPCS version under the `_audit_phpcs_phpcompatibility` meta key.

### Applicable Issues

Fixes #144.
Depends on wptide/pkg#21