### PR TITLE
fix typos and docs standards

### DIFF
--- a/cmd/lighthouse-server/main.go
+++ b/cmd/lighthouse-server/main.go
@@ -84,7 +84,7 @@ var (
 	// A single URL to process. Will not poll queue.
 	flagURL = &[]string{""}[0]
 
-	// Project visibility for URL. "private" or "public"
+	// Project visibility for URL. "private" or "public".
 	flagVisibility = &[]string{"private"}[0]
 
 	// The client login id in Tide API.
@@ -93,7 +93,7 @@ var (
 	// Send to Stdout rather than API?
 	flagOutput = &[]string{""}[0]
 
-	// Process Functions
+	// Process Functions.
 	doProcess = executeProcessFunc
 )
 
@@ -189,7 +189,7 @@ func main() {
 	for {
 		select {
 		case msg := <-cMessage:
-			// Process Message
+			// Process Message.
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 			err := processMessage(msg, &wg)

--- a/cmd/lighthouse-server/main_test.go
+++ b/cmd/lighthouse-server/main_test.go
@@ -28,20 +28,20 @@ var (
 		"API_SECRET":    "tideapisecret",
 		"API_VERSION":   "v1",
 		//
-		// AWS API settings
+		// AWS API settings.
 		"AWS_API_KEY":    "sqskey",
 		"AWS_API_SECRET": "sqssecret",
 		//
-		// AWS S3 settings
+		// AWS S3 settings.
 		"AWS_S3_BUCKET_NAME": "test-bucket",
 		"AWS_S3_REGION":      "us-west-2",
 		//
-		// AWS SQS settings
+		// AWS SQS settings.
 		"AWS_SQS_QUEUE_LH": "test-queue",
 		"AWS_SQS_REGION":   "us-west-2",
 		"AWS_SQS_VERSION":  "2012-11-05",
 		//
-		// LH Server settings
+		// LH Server settings.
 		"LH_CONCURRENT_AUDITS": "1",
 	}
 )
@@ -66,7 +66,7 @@ func Test_main(t *testing.T) {
 
 	resetServiceConfig()
 
-	// Use the mockTide for Tide
+	// Use the mockTide for Tide.
 	currentClient := TideClient
 	TideClient = &mockTide{}
 	defer func() { TideClient = currentClient }()
@@ -161,17 +161,17 @@ func Test_main(t *testing.T) {
 				}()
 			}
 
-			// -output
+			// -output.
 			if tt.args.flagOutput != nil && *tt.args.flagOutput != "" {
 				flagOutput = tt.args.flagOutput
 			}
 
-			// -url
+			// -url.
 			if tt.args.flagURL != nil && *tt.args.flagURL != "" {
 				flagURL = tt.args.flagURL
 			}
 
-			// -visibility
+			// -visibility.
 			if tt.args.flagVisibility != nil && *tt.args.flagVisibility != "" {
 				flagVisibility = tt.args.flagVisibility
 			}

--- a/cmd/phpcs-server/main.go
+++ b/cmd/phpcs-server/main.go
@@ -90,7 +90,7 @@ var (
 	// A single URL to process. Will not poll queue.
 	flagURL = &[]string{""}[0]
 
-	// Project visibility for URL. "private" or "public"
+	// Project visibility for URL. "private" or "public".
 	flagVisibility = &[]string{"private"}[0]
 
 	// The client login id in Tide API.
@@ -102,7 +102,7 @@ var (
 	// PHPCompatibility ruleset to use for WordPress projects.
 	flagWPRuleset = &[]string{""}[0]
 
-	// Process Functions
+	// Process Functions.
 	doProcess      = executeProcessFunc
 	doPHPCSProcess = executePHPCSProcessFunc
 )
@@ -217,7 +217,7 @@ func main() {
 	for {
 		select {
 		case msg := <-cMessage:
-			// Process Message
+			// Process Message.
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 			err := processMessage(msg, &wg)

--- a/cmd/phpcs-server/main_test.go
+++ b/cmd/phpcs-server/main_test.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	envTest = map[string]string{
-		// Tide API config
+		// Tide API config.
 		"API_AUTH_URL":  "http://tide.local/api/tide/v1/auth",
 		"API_HTTP_HOST": "tide.local",
 		"API_PROTOCOL":  "http",
@@ -31,20 +31,20 @@ var (
 		"API_SECRET":    "tideapisecret",
 		"API_VERSION":   "v1",
 		//
-		// AWS API settings
+		// AWS API settings.
 		"AWS_API_KEY":    "sqskey",
 		"AWS_API_SECRET": "sqssecret",
 		//
-		// AWS S3 settings
+		// AWS S3 settings.
 		"AWS_S3_BUCKET_NAME": "test-bucket",
 		"AWS_S3_REGION":      "us-west-2",
 		//
-		// AWS SQS settings
+		// AWS SQS settings.
 		"AWS_SQS_QUEUE_PHPCS": "test-queue",
 		"AWS_SQS_REGION":      "us-west-2",
 		"AWS_SQS_VERSION":     "2012-11-05",
 		//
-		// PHPCS Server settings
+		// PHPCS Server settings.
 		"PHPCS_CONCURRENT_AUDITS": "1",
 	}
 )
@@ -69,7 +69,7 @@ func Test_main(t *testing.T) {
 
 	resetServiceConfig()
 
-	// Use the mockTide for Tide
+	// Use the mockTide for Tide.
 	currentClient := TideClient
 	TideClient = &mockTide{}
 	defer func() { TideClient = currentClient }()
@@ -194,12 +194,12 @@ func Test_main(t *testing.T) {
 				}()
 			}
 
-			// -output
+			// -output.
 			if tt.args.flagOutput != nil && *tt.args.flagOutput != "" {
 				flagOutput = tt.args.flagOutput
 			}
 
-			// -url
+			// -url.
 			if tt.args.flagURL != nil && *tt.args.flagURL != "" {
 				flagURL = tt.args.flagURL
 				defer func() {
@@ -207,7 +207,7 @@ func Test_main(t *testing.T) {
 				}()
 			}
 
-			// -visibility
+			// -visibility.
 			if tt.args.flagVisibility != nil && *tt.args.flagVisibility != "" {
 				flagVisibility = tt.args.flagVisibility
 				defer func() {

--- a/cmd/sync-server/checker_test.go
+++ b/cmd/sync-server/checker_test.go
@@ -241,7 +241,7 @@ func Test_scribbleChecker_SetSyncTime(t *testing.T) {
 				"mock",
 				epoc,
 			},
-			"0", // Epoc is 0
+			"0", // Epoc is 0.
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/sync-server/firestore.go
+++ b/cmd/sync-server/firestore.go
@@ -14,7 +14,7 @@ type firestoreDispatcher struct {
 	Collections map[string]struct {
 		Collection string
 		Active     bool
-		Accepts    string // "all" or "themes" or "plugins"
+		Accepts    string // "all" or "themes" or "plugins".
 	}
 	providers map[string]message.Provider
 }
@@ -26,7 +26,7 @@ func (fs firestoreDispatcher) Dispatch(project wporg.RepoProject) error {
 	for collectionID, collection := range fs.Collections {
 		queueProvider, ok := fs.providers[collectionID]
 		if !ok {
-			return errors.New("could not access queue: make sure the dispatcher is initialised")
+			return errors.New("could not access queue: make sure the dispatcher is initialized")
 		}
 		if collection.Active && (collection.Accepts == project.Type || collection.Accepts == "all") {
 			err := queueProvider.SendMessage(msg)

--- a/cmd/sync-server/firestore_test.go
+++ b/cmd/sync-server/firestore_test.go
@@ -11,7 +11,7 @@ var (
 	testCollections = map[string]struct {
 		Collection string
 		Active     bool
-		Accepts    string // "all" or "themes" or "plugins"
+		Accepts    string // "all" or "themes" or "plugins".
 	}{
 		"queue1": {
 			"region1",

--- a/cmd/sync-server/main.go
+++ b/cmd/sync-server/main.go
@@ -295,7 +295,7 @@ func getDispatcher(c map[string]map[string]string) (sync.Dispatcher, error) {
 				Queue    string
 				Endpoint string
 				Active   bool
-				Accepts  string // "all" or "themes" or "plugins"
+				Accepts  string // "all" or "themes" or "plugins".
 			}{
 				"phpcs": {
 					conf["sqs_region"],
@@ -326,7 +326,7 @@ func getDispatcher(c map[string]map[string]string) (sync.Dispatcher, error) {
 			Collections: map[string]struct {
 				Collection string
 				Active     bool
-				Accepts    string // "all" or "themes" or "plugins"
+				Accepts    string // "all" or "themes" or "plugins".
 			}{
 				"phpcs": {
 					conf["phpcsCollection"],
@@ -354,7 +354,7 @@ func getDispatcher(c map[string]map[string]string) (sync.Dispatcher, error) {
 			Collections: map[string]struct {
 				Collection string
 				Active     bool
-				Accepts    string // "all" or "themes" or "plugins"
+				Accepts    string // "all" or "themes" or "plugins".
 			}{
 				"phpcs": {
 					conf["phpcsCollection"],

--- a/cmd/sync-server/main_test.go
+++ b/cmd/sync-server/main_test.go
@@ -245,7 +245,7 @@ func Test_fetcher(t *testing.T) {
 				}()
 			}
 
-			// Initialise a token.
+			// Initialize a token.
 			go func() { token <- struct{}{} }()
 
 			projects := fetcher(tt.args.projectType, tt.args.category, tt.args.bufferSize, tt.args.token, tt.args.maxPages)

--- a/cmd/sync-server/mongo.go
+++ b/cmd/sync-server/mongo.go
@@ -19,7 +19,7 @@ type mongoDispatcher struct {
 	Collections map[string]struct {
 		Collection string
 		Active     bool
-		Accepts    string // "all" or "themes" or "plugins"
+		Accepts    string // "all" or "themes" or "plugins".
 	}
 	providers map[string]message.Provider
 }

--- a/cmd/sync-server/mongo_test.go
+++ b/cmd/sync-server/mongo_test.go
@@ -12,7 +12,7 @@ var (
 	mongoCollections = map[string]struct {
 		Collection string
 		Active     bool
-		Accepts    string // "all" or "themes" or "plugins"
+		Accepts    string // "all" or "themes" or "plugins".
 	}{
 		"queue1": {
 			"region1",

--- a/cmd/sync-server/sqs.go
+++ b/cmd/sync-server/sqs.go
@@ -16,7 +16,7 @@ type sqsDispatcher struct {
 		Queue    string
 		Endpoint string
 		Active   bool
-		Accepts  string // "all" or "themes" or "plugins"
+		Accepts  string // "all" or "themes" or "plugins".
 	}
 	providers map[string]message.Provider
 }

--- a/service/api/tpl/wp-config.tpl
+++ b/service/api/tpl/wp-config.tpl
@@ -21,14 +21,14 @@
 // $is_gae is true on Google App Engine.
 $is_gae = ( getenv( 'GAE_VERSION' ) !== false );
 
-// Register GCS stream wrapper
+// Register GCS stream wrapper.
 if ( $is_gae || 'gcs' === getenv( 'API_UPLOAD_HANDLER' ) ) {
     require_once( __DIR__ . '/../vendor/autoload.php' );
     $storageClient = new Google\Cloud\Storage\StorageClient();
     $storageClient->registerStreamWrapper();
 }
 
-// Disable pseudo cron behavior
+// Disable pseudo cron behavior.
 define( 'DISABLE_WP_CRON', true );
 
 // Use HTTPS on production.
@@ -45,7 +45,7 @@ if ( isset( $_SERVER['HTTP_HOST'] ) ) {
 define( 'WP_HOME', $protocol . HTTP_HOST );
 define( 'WP_SITEURL', $protocol . HTTP_HOST );
 
-// Force SSL for admin pages
+// Force SSL for admin pages.
 define( 'FORCE_SSL_ADMIN', $is_gae );
 
 // Security settings.

--- a/service/api/wp-content/mu-plugins/advanced-post-cache.php
+++ b/service/api/wp-content/mu-plugins/advanced-post-cache.php
@@ -15,29 +15,29 @@ if ( ! defined( 'WP_CACHE' ) || true !== WP_CACHE ) {
 class Advanced_Post_Cache {
 	var $CACHE_GROUP_PREFIX = 'advanced_post_cache_';
 
-	// Flag for temp (within one page load) turning invalidations on and off
-	// @see dont_clear_advanced_post_cache()
-	// @see do_clear_advanced_post_cache()
-	// Used to prevent invalidation during new comment
+	// Flag for temp (within one page load) turning invalidations on and off.
+	// @see dont_clear_advanced_post_cache().
+	// @see do_clear_advanced_post_cache().
+	// Used to prevent invalidation during new comment.
 	var $do_flush_cache = true;
 
 	// Flag for preventing multiple invalidations in a row: clean_post_cache() calls itself recursively for post children.
-	var $need_to_flush_cache = true; // Currently disabled
+	var $need_to_flush_cache = true; // Currently disabled.
 
 	/* Per cache-clear data */
 	var $cache_incr = 0; // Increments the cache group (advanced_post_cache_0, advanced_post_cache_1, ...)
-	var $cache_group = ''; // CACHE_GROUP_PREFIX . $cache_incr
+	var $cache_group = ''; // CACHE_GROUP_PREFIX . $cache_incr.
 
 	/* Per query data */
-	var $cache_key = ''; // md5 of current SQL query
-	var $all_post_ids = false; // IDs of all posts current SQL query returns
-	var $cached_post_ids = array(); // Subset of $all_post_ids whose posts are currently in cache
+	var $cache_key = ''; // md5 of current SQL query.
+	var $all_post_ids = false; // IDs of all posts current SQL query returns.
+	var $cached_post_ids = array(); // Subset of $all_post_ids whose posts are currently in cache.
 	var $cached_posts = array();
-	var $found_posts = false; // The result of the FOUND_ROWS() query
-	var $cache_func = 'wp_cache_add'; // Turns to set if there seems to be inconsistencies
+	var $found_posts = false; // The result of the FOUND_ROWS() query.
+	var $cache_func = 'wp_cache_add'; // Turns to set if there seems to be inconsistencies.
 
 	function __construct() {
-		// Specific to certain Memcached Object Cache plugins
+		// Specific to certain Memcached Object Cache plugins.
 		if ( function_exists( 'wp_cache_add_group_prefix_map' ) ) {
 			wp_cache_add_group_prefix_map( $this->CACHE_GROUP_PREFIX, 'advanced_post_cache' );
 		}
@@ -46,13 +46,13 @@ class Advanced_Post_Cache {
 
 		add_action( 'switch_blog', array( $this, 'setup_for_blog' ), 10, 2 );
 
-		add_filter( 'posts_request', array( &$this, 'posts_request' ) ); // Short circuits if cached
-		add_filter( 'posts_results', array( &$this, 'posts_results' ) ); // Collates if cached, primes cache if not
+		add_filter( 'posts_request', array( &$this, 'posts_request' ) ); // Short circuits if cached.
+		add_filter( 'posts_results', array( &$this, 'posts_results' ) ); // Collates if cached, primes cache if not.
 
-		add_filter( 'post_limits_request', array( &$this, 'post_limits_request' ), 999, 2 ); // Checks to see if we need to worry about found_posts
+		add_filter( 'post_limits_request', array( &$this, 'post_limits_request' ), 999, 2 ); // Checks to see if we need to worry about found_posts.
 
-		add_filter( 'found_posts_query', array( &$this, 'found_posts_query' ) ); // Short circuits if cached
-		add_filter( 'found_posts', array( &$this, 'found_posts' ) ); // Reads from cache if cached, primes cache if not
+		add_filter( 'found_posts_query', array( &$this, 'found_posts_query' ) ); // Short circuits if cached.
+		add_filter( 'found_posts', array( &$this, 'found_posts' ) ); // Reads from cache if cached, primes cache if not.
 	}
 
 	function setup_for_blog( $new_blog_id = false, $previous_blog_id = false ) {
@@ -60,7 +60,7 @@ class Advanced_Post_Cache {
 			return;
 		}
 
-		$this->cache_incr = wp_cache_get( 'advanced_post_cache', 'cache_incrementors' ); // Get and construct current cache group name
+		$this->cache_incr = wp_cache_get( 'advanced_post_cache', 'cache_incrementors' ); // Get and construct current cache group name.
 		if ( !is_numeric( $this->cache_incr ) ) {
 			$now = time();
 			wp_cache_set( 'advanced_post_cache', $now, 'cache_incrementors' );
@@ -75,15 +75,15 @@ class Advanced_Post_Cache {
 	 * Flushes the cache by incrementing the cache group
 	 */
 	function flush_cache() {
-		// Cache flushes have been disabled
+		// Cache flushes have been disabled.
 		if ( !$this->do_flush_cache )
 			return;
 
-		// Bail on post preview
+		// Bail on post preview.
 		if ( is_admin() && isset( $_POST['wp-preview'] ) && 'dopreview' == $_POST['wp-preview'] )
 			return;
 
-		// Bail on autosave
+		// Bail on autosave.
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
 			return;
 
@@ -113,7 +113,7 @@ class Advanced_Post_Cache {
 	function posts_request( $sql ) {
 		global $wpdb;
 
-		$this->cache_key = md5( $sql ); // init
+		$this->cache_key = md5( $sql ); // Init.
 		$this->all_post_ids = wp_cache_get( $this->cache_key, $this->cache_group );
 		if ( 'NA' !== $this->found_posts )
 			$this->found_posts = wp_cache_get( "{$this->cache_key}_found", $this->cache_group );
@@ -123,10 +123,10 @@ class Advanced_Post_Cache {
 		else
 			$this->cache_func = 'wp_cache_add';
 
-		$this->cached_post_ids = array(); // re-init
-		$this->cached_posts = array(); // re-init
+		$this->cached_post_ids = array(); // Re-init.
+		$this->cached_posts = array(); // Re-init.
 
-		// Query is cached
+		// Query is cached.
 		if ( $this->found_posts && is_array( $this->all_post_ids ) ) {
 			if ( function_exists( 'wp_cache_get_multi' ) ) {
 				$this->cached_posts = wp_cache_get_multi( array( 'posts' => $this->all_post_ids ) );
@@ -192,7 +192,7 @@ class Advanced_Post_Cache {
 		if ( empty( $limits ) || ( isset( $query->query_vars['no_found_rows'] ) && $query->query_vars['no_found_rows'] ) )
 			$this->found_posts = 'NA';
 		else
-			$this->found_posts = false; // re-init
+			$this->found_posts = false; // Re-init.
 		return $limits;
 	}
 
@@ -201,7 +201,7 @@ class Advanced_Post_Cache {
 	 * Otherwise: Returns query unchanged.
 	 */
 	function found_posts_query( $sql ) {
-		if ( $this->found_posts && is_array( $this->all_post_ids ) ) // is cached
+		if ( $this->found_posts && is_array( $this->all_post_ids ) ) // Is cached.
 			return '';
 		return $sql;
 	}
@@ -211,7 +211,7 @@ class Advanced_Post_Cache {
 	 * Otherwise: Returs result unchanged
 	 */
 	function found_posts( $found_posts ) {
-		if ( $this->found_posts && is_array( $this->all_post_ids ) ) // is cached
+		if ( $this->found_posts && is_array( $this->all_post_ids ) ) // Is cached.
 			return (int) $this->found_posts;
 
 		call_user_func( $this->cache_func, "{$this->cache_key}_found", (int) $found_posts, $this->cache_group );
@@ -240,7 +240,7 @@ function dont_clear_advanced_post_cache() {
 add_action( 'clean_term_cache', 'clear_advanced_post_cache' );
 add_action( 'clean_post_cache', 'clear_advanced_post_cache' );
 
-// Don't clear Advanced Post Cache for a new comment - temp core hack
-// http://core.trac.wordpress.org/ticket/15565
+// Don't clear Advanced Post Cache for a new comment - temp core hack.
+// http://core.trac.wordpress.org/ticket/15565.
 add_action( 'wp_updating_comment_count', 'dont_clear_advanced_post_cache' );
 add_action( 'wp_update_comment_count', 'do_clear_advanced_post_cache' );


### PR DESCRIPTION
fix typos and docs standards

following to

https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#5-1-single-line-comments 