### PR TITLE
Never use shorthand PHP start tags. Always use full PHP tags.

### DIFF
--- a/service/api/wp-content/mu-plugins/gcs-upload.php
+++ b/service/api/wp-content/mu-plugins/gcs-upload.php
@@ -73,7 +73,7 @@ class Upload {
 		}
 		?>
 		<div class="wrap">
-			<h1><?= esc_html( get_admin_page_title() ); ?></h1>
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 			<form action="options.php" method="POST">
 				<?php
 


### PR DESCRIPTION
### No Shorthand PHP Tags

Important: Never use shorthand PHP start tags. Always use full PHP tags.

As per WordPress PHP coding standards, the use of shorthand PHP tags is discouraged. Therefore, I kindly request that you modify the code to comply with this standard.

Check documentation URL : https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#no-shorthand-php-tags