### PR TITLE
Fix typos and incorrect function comments

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -6,7 +6,7 @@ Do you want to ask a question? Are you looking for support? The [`#tide` channel
 
 BEFORE POSTING YOUR ISSUE:
 - These comments won't show up when you submit the issue.
-- Try to add as much detail as possible, please de specific.
+- Try to add as much detail as possible, please be specific.
 - If you're requesting a new feature, explain why you'd like it to be added.
 - Ensure you are using the latest code before logging bugs.
 

--- a/cmd/lighthouse-server/main.go
+++ b/cmd/lighthouse-server/main.go
@@ -116,7 +116,7 @@ func main() {
 		flagURL = flag.String("url", "", "audit single message from url")
 
 		// A -visibility to run a single audit. Will not poll a queue.
-		flagVisibility = flag.String("visibility", "public", `"private" or "public" - default "pubic"`)
+		flagVisibility = flag.String("visibility", "public", `"private" or "public" - default "public"`)
 
 		// The -client login name in Tide API.
 		flagClient = flag.String("client", "wporg", `Tide API client to attribute project to - default "wporg"`)
@@ -331,7 +331,7 @@ func getStorageProvider(config map[string]map[string]string) storage.Provider {
 	}
 }
 
-// getStorageProvider returns a message/queue provider given the provided configurations
+// getMessageProvider returns a message/queue provider given the provided configurations
 // from the environment variables.
 func getMessageProvider(config map[string]map[string]string) message.Provider {
 

--- a/cmd/phpcs-server/main.go
+++ b/cmd/phpcs-server/main.go
@@ -126,7 +126,7 @@ func main() {
 		flagURL = flag.String("url", "", "Audit single message from url")
 
 		// A -visibility to run a single audit. Will not poll a queue.
-		flagVisibility = flag.String("visibility", "public", `"private" or "public" - default "pubic"`)
+		flagVisibility = flag.String("visibility", "public", `"private" or "public" - default "public"`)
 
 		// The -client login name in Tide API.
 		flagClient = flag.String("client", "wporg", `Tide API client to attribute project to - default "wporg"`)
@@ -408,7 +408,7 @@ func getStorageProvider(config map[string]map[string]string) storage.Provider {
 	}
 }
 
-// getStorageProvider returns a message/queue provider given the provided configurations
+// getMessageProvider returns a message/queue provider given the provided configurations
 // from the environment variables.
 func getMessageProvider(config map[string]map[string]string) message.Provider {
 	switch config["app"]["message_provider"] {


### PR DESCRIPTION
### Description of the Change

This PR fixes typos and incorrect comments:

- Fix `"pubic"` → `"public"` typo in visibility flag (lighthouse-server & phpcs-server)
- Fix `"de specific"` → `"be specific"` typo in ISSUE_TEMPLATE.md
- Fix incorrect [getStorageProvider](cci:1://file:///Users/noruzzamanrubel/Desktop/WPContribution/wptide/cmd/phpcs-server/main.go:393:0-408:1) comment → [getMessageProvider](cci:1://file:///Users/noruzzamanrubel/Desktop/WPContribution/wptide/cmd/phpcs-server/main.go:410:0-428:1) in both servers

### Benefits

- Improves code readability
- Fixes typo in CLI help text

### Verification Process

Manual review only - no functional changes.